### PR TITLE
Split export to lib

### DIFF
--- a/.changeset/open-lamps-act.md
+++ b/.changeset/open-lamps-act.md
@@ -1,0 +1,5 @@
+---
+'@viamrobotics/motion-tools': minor
+---
+
+Split library export to /lib

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ static/Big_Buck_Bunny_4K.webm
 /.svelte-kit
 /build
 /dist
+viamrobotics-motion-tools-*.tgz
 
 # OS
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -115,6 +115,10 @@
 		".": {
 			"types": "./dist/index.d.ts",
 			"svelte": "./dist/index.js"
+		},
+		"./lib": {
+			"types": "./dist/lib.d.ts",
+			"svelte": "./dist/lib.js"
 		}
 	},
 	"repository": {

--- a/src/lib/components/CameraControls.svelte
+++ b/src/lib/components/CameraControls.svelte
@@ -14,14 +14,14 @@
 		Vector3,
 		Vector4,
 	} from 'three'
-	import Controls from 'camera-controls'
+	import CameraController from 'camera-controls'
 	import { T, useTask, useThrelte } from '@threlte/core'
 	import type { Snippet } from 'svelte'
 
 	let installed = false
 
 	const install = () => {
-		Controls.install({
+		CameraController.install({
 			THREE: {
 				Box3,
 				Matrix4,
@@ -40,7 +40,7 @@
 
 <script lang="ts">
 	interface Props {
-		ref?: Controls
+		ref?: CameraController
 		enabled?: boolean
 		children?: Snippet
 	}
@@ -53,7 +53,7 @@
 
 	const { camera, dom, invalidate } = useThrelte()
 
-	const controls = new Controls(camera.current as PerspectiveCamera, dom)
+	const controls = new CameraController(camera.current as PerspectiveCamera, dom)
 
 	$effect.pre(() => {
 		controls.camera = $camera as PerspectiveCamera

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,10 +1,1 @@
 export { default as MotionTools } from './components/App.svelte'
-
-export { default as CameraControls } from './components/CameraControls.svelte'
-export { default as Geometry } from './components/Geometry.svelte'
-
-export { AxesHelper } from './three/AxesHelper'
-export { BatchedArrow } from './three/BatchedArrow'
-export { CapsuleGeometry } from './three/CapsuleGeometry'
-
-export { WorldObject } from './WorldObject'

--- a/src/lib/lib.ts
+++ b/src/lib/lib.ts
@@ -1,0 +1,9 @@
+export { default as CameraControls } from './components/CameraControls.svelte'
+export { type default as CameraController } from 'camera-controls'
+export { default as Geometry } from './components/Geometry.svelte'
+
+export { AxesHelper } from './three/AxesHelper'
+export { BatchedArrow } from './three/BatchedArrow'
+export { CapsuleGeometry } from './three/CapsuleGeometry'
+
+export { WorldObject } from './WorldObject'


### PR DESCRIPTION
Splits exports we want to use in other apps into `lib.ts` and keep `index.ts` for exporting the main application.