### PR TITLE
Add trailing url check

### DIFF
--- a/.changeset/lucky-bikes-joke.md
+++ b/.changeset/lucky-bikes-joke.md
@@ -1,0 +1,5 @@
+---
+"@viamrobotics/motion-tools": patch
+---
+
+Add trailing url check

--- a/client/client/client.go
+++ b/client/client/client.go
@@ -132,6 +132,9 @@ func postHTTP(data []byte, content string, endpoint string) error {
 // Parameters:
 //   - preferredURL: a url string
 func SetURL(preferredURL string) {
+	if !strings.HasSuffix(preferredURL, "/") {
+		preferredURL += "/"
+	}
 	url = preferredURL
 }
 


### PR DESCRIPTION
Checks to make sure the provided url has a trailing `/` so that it creates correct requests