### PR TITLE
Put geometries back in the same world object

### DIFF
--- a/.changeset/brown-taxes-tap.md
+++ b/.changeset/brown-taxes-tap.md
@@ -1,0 +1,5 @@
+---
+'@viamrobotics/motion-tools': patch
+---
+
+Display only one tree entry for frames with geometries

--- a/src/lib/WorldObject.svelte.ts
+++ b/src/lib/WorldObject.svelte.ts
@@ -11,10 +11,17 @@ import {
 } from 'three'
 import { createPose } from './transform'
 
-export type PointsGeometry = { case: 'points'; value: Float32Array<ArrayBuffer> }
-export type LinesGeometry = { case: 'line'; value: Float32Array }
+export type PointsGeometry = {
+	center: undefined
+	geometryType: { case: 'points'; value: Float32Array<ArrayBuffer> }
+}
 
-export type Geometries = Geometry['geometryType'] | PointsGeometry | LinesGeometry
+export type LinesGeometry = {
+	center: undefined
+	geometryType: { case: 'line'; value: Float32Array }
+}
+
+export type Geometries = Geometry | PointsGeometry | LinesGeometry
 
 export type Metadata = {
 	colors?: Float32Array
@@ -107,7 +114,7 @@ export const fromTransform = (transform: TransformWithUUID) => {
 		transform.referenceFrame,
 		transform.poseInObserverFrame?.pose,
 		transform.poseInObserverFrame?.referenceFrame,
-		transform.physicalObject?.geometryType,
+		transform.physicalObject,
 		metadata
 	)
 	worldObject.uuid = transform.uuidString

--- a/src/lib/components/Details.svelte
+++ b/src/lib/components/Details.svelte
@@ -227,8 +227,8 @@
 			</WeblabActive>
 
 			{#if geometry}
-				{#if geometry.case === 'box'}
-					{@const { dimsMm } = geometry.value}
+				{#if geometry.geometryType.case === 'box'}
+					{@const { dimsMm } = geometry.geometryType.value}
 					<div>
 						<strong class="font-semibold">dimensions (box)</strong>
 						<div class="flex gap-3">
@@ -246,8 +246,8 @@
 							</div>
 						</div>
 					</div>
-				{:else if geometry.case === 'capsule'}
-					{@const { value } = geometry}
+				{:else if geometry.geometryType.case === 'capsule'}
+					{@const { value } = geometry.geometryType}
 					<div>
 						<strong class="font-semibold">dimensions (capsule)</strong>
 						<div class="flex gap-3">
@@ -261,14 +261,14 @@
 							</div>
 						</div>
 					</div>
-				{:else if geometry.case === 'sphere'}
+				{:else if geometry.geometryType.case === 'sphere'}
 					<div class="flex justify-between">
 						<div>
 							<strong class="font-semibold">dimensions (sphere)</strong>
 							<div class="flex gap-3">
 								<div>
 									<span class="text-subtle-2">r</span>
-									{geometry.value.radiusMm.toFixed(2)}
+									{geometry.geometryType.value.radiusMm.toFixed(2)}
 								</div>
 							</div>
 						</div>

--- a/src/lib/components/FileDrop.svelte
+++ b/src/lib/components/FileDrop.svelte
@@ -83,8 +83,11 @@
 						undefined,
 						undefined,
 						{
-							case: 'points',
-							value: result.positions,
+							center: undefined,
+							geometryType: {
+								case: 'points',
+								value: result.positions,
+							},
 						},
 						result.colors ? { colors: result.colors } : undefined
 					)

--- a/src/lib/components/Geometry.svelte
+++ b/src/lib/components/Geometry.svelte
@@ -83,28 +83,28 @@
 			{uuid}
 			bvh={{ enabled: false }}
 		>
-			{#if geometry?.geometryType.case === 'mesh'}
+			{#if geometry.geometryType.case === 'mesh'}
 				{@const mesh = geometry.geometryType.value.mesh as Uint8Array<ArrayBuffer>}
 				{@const meshGeometry = plyLoader.parse(typeof mesh === 'string' ? atob(mesh) : mesh.buffer)}
 				<T
 					is={meshGeometry}
 					{oncreate}
 				/>
-			{:else if geometry?.geometryType.case === 'line' && metadata.points}
+			{:else if geometry.geometryType.case === 'line' && metadata.points}
 				<MeshLineGeometry points={metadata.points} />
-			{:else if geometry?.geometryType.case === 'box'}
+			{:else if geometry.geometryType.case === 'box'}
 				{@const dimsMm = geometry.geometryType.value.dimsMm ?? { x: 0, y: 0, z: 0 }}
 				<T.BoxGeometry
 					args={[dimsMm.x * 0.001, dimsMm.y * 0.001, dimsMm.z * 0.001]}
 					{oncreate}
 				/>
-			{:else if geometry?.geometryType.case === 'sphere'}
+			{:else if geometry.geometryType.case === 'sphere'}
 				{@const radiusMm = geometry.geometryType.value.radiusMm ?? 0}
 				<T.SphereGeometry
 					args={[radiusMm * 0.001]}
 					{oncreate}
 				/>
-			{:else if geometry?.geometryType.case === 'capsule'}
+			{:else if geometry.geometryType.case === 'capsule'}
 				{@const { lengthMm, radiusMm } = geometry.geometryType.value}
 				<T
 					is={CapsuleGeometry}
@@ -113,15 +113,15 @@
 				/>
 			{:else}{/if}
 
-			{#if geometry?.geometryType.case === 'line'}
+			{#if geometry.geometryType.case === 'line'}
 				<MeshLineMaterial
 					{color}
 					width={metadata.lineWidth ?? 0.005}
 				/>
-			{:else if geometry}
+			{:else}
 				<T.MeshToonMaterial
 					{color}
-					side={geometry?.geometryType.case === 'mesh' ? DoubleSide : FrontSide}
+					side={geometry.geometryType.case === 'mesh' ? DoubleSide : FrontSide}
 					transparent
 					opacity={metadata.opacity ?? 0.7}
 				/>

--- a/src/lib/components/Geometry.svelte
+++ b/src/lib/components/Geometry.svelte
@@ -2,7 +2,7 @@
 	import { T, type Props as ThrelteProps } from '@threlte/core'
 	import { type Snippet } from 'svelte'
 	import { meshBounds, MeshLineGeometry, MeshLineMaterial } from '@threlte/extras'
-	import { BufferGeometry, DoubleSide, FrontSide, Mesh, Object3D } from 'three'
+	import { BufferGeometry, DoubleSide, FrontSide, Group, Mesh } from 'three'
 	import { CapsuleGeometry } from '$lib/three/CapsuleGeometry'
 	import { poseToObject3d } from '$lib/transform'
 	import { colors, darkenColor } from '$lib/color'
@@ -12,13 +12,13 @@
 
 	const plyLoader = new PLYLoader()
 
-	interface Props extends ThrelteProps<Object3D> {
+	interface Props extends ThrelteProps<Group> {
 		uuid: string
 		name: string
 		geometry?: WorldObject['geometry']
 		pose: WorldObject['pose']
 		metadata: WorldObject['metadata']
-		children?: Snippet<[{ ref: Object3D }]>
+		children?: Snippet<[{ ref: Group }]>
 		color?: string
 	}
 
@@ -33,19 +33,31 @@
 		...rest
 	}: Props = $props()
 
-	const type = $derived(geometry?.case)
+	const type = $derived(geometry?.geometryType?.case)
+	const color = $derived(overrideColor ?? metadata.color ?? colors.default)
+
+	const group = new Group()
 	const mesh = $derived.by(() => {
-		const object3d = type === undefined ? new Object3D() : new Mesh()
+		if (type === undefined) {
+			return
+		}
+		const result = new Mesh()
 
 		if (type === 'mesh' || type === 'points' || type === 'line') {
-			object3d.raycast = meshBounds
+			result.raycast = meshBounds
 		}
 
-		return object3d
+		return result
 	})
 
 	$effect.pre(() => {
-		poseToObject3d(pose, mesh)
+		if (geometry?.center && mesh) {
+			poseToObject3d(geometry.center, mesh)
+		}
+	})
+
+	$effect.pre(() => {
+		poseToObject3d(pose, group)
 	})
 
 	let geo = $state.raw<BufferGeometry>()
@@ -53,75 +65,79 @@
 	const oncreate = (ref: BufferGeometry) => {
 		geo = ref
 	}
-
-	const color = $derived(overrideColor ?? metadata.color ?? colors.default)
 </script>
 
 <T
-	is={mesh}
-	{name}
-	{uuid}
+	is={group}
 	{...rest}
-	bvh={{ enabled: false }}
 >
-	{#if geometry?.case === 'mesh'}
-		{@const mesh = geometry.value.mesh as Uint8Array<ArrayBuffer>}
-		{@const meshGeometry = plyLoader.parse(typeof mesh === 'string' ? atob(mesh) : mesh.buffer)}
+	<AxesHelper
+		width={3}
+		length={0.1}
+	/>
+
+	{#if geometry?.geometryType}
 		<T
-			is={meshGeometry}
-			{oncreate}
-		/>
-	{:else if geometry?.case === 'line' && metadata.points}
-		<MeshLineGeometry points={metadata.points} />
-	{:else if geometry?.case === 'box'}
-		{@const dimsMm = geometry.value.dimsMm ?? { x: 0, y: 0, z: 0 }}
-		<T.BoxGeometry
-			args={[dimsMm.x * 0.001, dimsMm.y * 0.001, dimsMm.z * 0.001]}
-			{oncreate}
-		/>
-	{:else if geometry?.case === 'sphere'}
-		{@const radiusMm = geometry.value.radiusMm ?? 0}
-		<T.SphereGeometry
-			args={[radiusMm * 0.001]}
-			{oncreate}
-		/>
-	{:else if geometry?.case === 'capsule'}
-		{@const { lengthMm, radiusMm } = geometry.value}
-		<T
-			is={CapsuleGeometry}
-			args={[radiusMm * 0.001, lengthMm * 0.001]}
-			{oncreate}
-		/>
-	{:else}
-		<AxesHelper
-			width={3}
-			length={0.1}
-		/>
+			is={mesh}
+			{name}
+			{uuid}
+			bvh={{ enabled: false }}
+		>
+			{#if geometry?.geometryType.case === 'mesh'}
+				{@const mesh = geometry.geometryType.value.mesh as Uint8Array<ArrayBuffer>}
+				{@const meshGeometry = plyLoader.parse(typeof mesh === 'string' ? atob(mesh) : mesh.buffer)}
+				<T
+					is={meshGeometry}
+					{oncreate}
+				/>
+			{:else if geometry?.geometryType.case === 'line' && metadata.points}
+				<MeshLineGeometry points={metadata.points} />
+			{:else if geometry?.geometryType.case === 'box'}
+				{@const dimsMm = geometry.geometryType.value.dimsMm ?? { x: 0, y: 0, z: 0 }}
+				<T.BoxGeometry
+					args={[dimsMm.x * 0.001, dimsMm.y * 0.001, dimsMm.z * 0.001]}
+					{oncreate}
+				/>
+			{:else if geometry?.geometryType.case === 'sphere'}
+				{@const radiusMm = geometry.geometryType.value.radiusMm ?? 0}
+				<T.SphereGeometry
+					args={[radiusMm * 0.001]}
+					{oncreate}
+				/>
+			{:else if geometry?.geometryType.case === 'capsule'}
+				{@const { lengthMm, radiusMm } = geometry.geometryType.value}
+				<T
+					is={CapsuleGeometry}
+					args={[radiusMm * 0.001, lengthMm * 0.001]}
+					{oncreate}
+				/>
+			{:else}{/if}
+
+			{#if geometry?.geometryType.case === 'line'}
+				<MeshLineMaterial
+					{color}
+					width={metadata.lineWidth ?? 0.005}
+				/>
+			{:else if geometry}
+				<T.MeshToonMaterial
+					{color}
+					side={geometry?.geometryType.case === 'mesh' ? DoubleSide : FrontSide}
+					transparent
+					opacity={metadata.opacity ?? 0.7}
+				/>
+
+				{#if geo}
+					<T.LineSegments
+						raycast={() => null}
+						bvh={{ enabled: false }}
+					>
+						<T.EdgesGeometry args={[geo, 0]} />
+						<T.LineBasicMaterial color={darkenColor(color, 10)} />
+					</T.LineSegments>
+				{/if}
+			{/if}
+		</T>
 	{/if}
 
-	{#if geometry?.case === 'line'}
-		<MeshLineMaterial
-			{color}
-			width={metadata.lineWidth ?? 0.005}
-		/>
-	{:else if geometry}
-		<T.MeshToonMaterial
-			{color}
-			side={geometry.case === 'mesh' ? DoubleSide : FrontSide}
-			transparent
-			opacity={metadata.opacity ?? 0.7}
-		/>
-
-		{#if geo}
-			<T.LineSegments
-				raycast={() => null}
-				bvh={{ enabled: false }}
-			>
-				<T.EdgesGeometry args={[geo, 0]} />
-				<T.LineBasicMaterial color={darkenColor(color, 10)} />
-			</T.LineSegments>
-		{/if}
-	{/if}
-
-	{@render children?.({ ref: mesh })}
+	{@render children?.({ ref: group })}
 </T>

--- a/src/lib/components/Pointcloud.svelte
+++ b/src/lib/components/Pointcloud.svelte
@@ -7,14 +7,14 @@
 		OrthographicCamera,
 	} from 'three'
 	import { T, useTask, useThrelte } from '@threlte/core'
-	import type { WorldObject } from '$lib/WorldObject.svelte'
+	import type { PointsGeometry, WorldObject } from '$lib/WorldObject.svelte'
 	import { useObjectEvents } from '$lib/hooks/useObjectEvents.svelte'
 	import { poseToObject3d } from '$lib/transform'
 	import { useSettings } from '$lib/hooks/useSettings.svelte'
 	import type { Snippet } from 'svelte'
 
 	interface Props {
-		object: WorldObject<{ case: 'points'; value: Float32Array<ArrayBuffer> }>
+		object: WorldObject<PointsGeometry>
 		children?: Snippet
 	}
 
@@ -25,7 +25,7 @@
 
 	const colors = $derived(object.metadata.colors)
 	const pointSize = $derived(object.metadata.pointSize ?? settings.current.pointSize)
-	const positions = $derived(object.geometry?.value ?? new Float32Array())
+	const positions = $derived(object.geometry?.geometryType?.value ?? new Float32Array())
 	const orthographic = $derived(settings.current.cameraMode === 'orthographic')
 
 	const points = new Points()

--- a/src/lib/components/StaticGeometries.svelte
+++ b/src/lib/components/StaticGeometries.svelte
@@ -59,8 +59,8 @@
 							} else if (mode === 'rotate') {
 								quaternionToPose(ref.getWorldQuaternion(quaternion), object.pose)
 								ref.quaternion.copy(quaternion)
-							} else if (mode === 'scale' && object.geometry?.case === 'box') {
-								scaleToDimensions(ref.scale, object.geometry)
+							} else if (mode === 'scale' && object.geometry?.geometryType.case === 'box') {
+								scaleToDimensions(ref.scale, object.geometry.geometryType)
 								ref.scale.setScalar(1)
 							}
 						}}

--- a/src/lib/components/__tests__/Details.svelte.spec.ts
+++ b/src/lib/components/__tests__/Details.svelte.spec.ts
@@ -5,6 +5,7 @@ import Details from '../Details.svelte'
 import * as useSelection from '$lib/hooks/useSelection.svelte'
 import * as useWeblabs from '$lib/hooks/useWeblabs.svelte'
 import { Weblab } from '$lib/hooks/useWeblabs.svelte'
+import type { Geometry } from '@viamrobotics/sdk'
 
 describe('Details component', () => {
 	const mockedWeblab = new Weblab()
@@ -26,12 +27,15 @@ describe('Details component', () => {
 					theta: 0.4,
 				},
 				geometry: {
-					case: 'box',
-					value: {
-						dimsMm: { x: 10, y: 20, z: 30 },
+					label: 'my geometry',
+					geometryType: {
+						case: 'box',
+						value: {
+							dimsMm: { x: 10, y: 20, z: 30 },
+						},
 					},
-				},
-				metadata: { batched: undefined },
+				} satisfies Geometry,
+				metadata: {},
 			},
 		})
 		vi.mocked(useSelection.useFocusedObject3d).mockReturnValue({

--- a/src/lib/hooks/useDrawAPI.svelte.ts
+++ b/src/lib/hooks/useDrawAPI.svelte.ts
@@ -121,7 +121,7 @@ export const provideDrawAPI = () => {
 			return
 		}
 
-		let geometry: Geometry = {
+		const geometry: Geometry = {
 			label: data.label,
 			center: undefined,
 			geometryType: {

--- a/src/lib/hooks/useDrawAPI.svelte.ts
+++ b/src/lib/hooks/useDrawAPI.svelte.ts
@@ -101,8 +101,11 @@ export const provideDrawAPI = () => {
 				undefined,
 				undefined,
 				{
-					case: 'points',
-					value: positions,
+					center: undefined,
+					geometryType: {
+						case: 'points',
+						value: positions,
+					},
 				},
 				colors ? { colors } : undefined
 			)
@@ -118,21 +121,26 @@ export const provideDrawAPI = () => {
 			return
 		}
 
-		let geometry: Geometry['geometryType']
+		let geometry: Geometry = {
+			label: data.label,
+			center: undefined,
+			geometryType: {
+				case: undefined,
+			},
+		}
 
 		if ('mesh' in data) {
-			geometry = {
-				case: 'mesh',
-				value: { contentType: '', mesh: data.mesh.mesh },
-			}
+			geometry.geometryType.case = 'mesh'
+			geometry.geometryType.value = data.mesh
 		} else if ('box' in data) {
-			geometry = { case: 'box', value: data.box }
+			geometry.geometryType.case = 'box'
+			geometry.geometryType.value = data.box
 		} else if ('sphere' in data) {
-			geometry = { case: 'sphere', value: data.sphere }
+			geometry.geometryType.case = 'sphere'
+			geometry.geometryType.value = data.sphere
 		} else if ('capsule' in data) {
-			geometry = { case: 'capsule', value: data.capsule }
-		} else {
-			geometry = { case: undefined, value: undefined }
+			geometry.geometryType.case = 'capsule'
+			geometry.geometryType.value = data.capsule
 		}
 
 		const object = new WorldObject(data.label ?? ++geometryIndex, data.center, parent, geometry, {
@@ -157,7 +165,7 @@ export const provideDrawAPI = () => {
 			data.name,
 			data.pose,
 			data.parent,
-			{ case: 'line', value: new Float32Array() },
+			{ center: undefined, geometryType: { case: 'line', value: new Float32Array() } },
 			{ color, points: curve.getPoints(200) }
 		)
 
@@ -280,8 +288,11 @@ export const provideDrawAPI = () => {
 				undefined,
 				undefined,
 				{
-					case: 'points',
-					value: positions,
+					center: undefined,
+					geometryType: {
+						case: 'points',
+						value: positions,
+					},
 				},
 				metadata
 			)
@@ -330,8 +341,11 @@ export const provideDrawAPI = () => {
 				undefined,
 				undefined,
 				{
-					case: 'line',
-					value: positions,
+					center: undefined,
+					geometryType: {
+						case: 'line',
+						value: positions,
+					},
 				},
 				{
 					points,

--- a/src/lib/hooks/useFrames.svelte.ts
+++ b/src/lib/hooks/useFrames.svelte.ts
@@ -49,25 +49,15 @@ export const provideFrames = (partID: () => string) => {
 				new WorldObject(
 					frameName,
 					frame.poseInObserverFrame?.pose,
-					frame.poseInObserverFrame?.referenceFrame
+					frame.poseInObserverFrame?.referenceFrame,
+					frame.physicalObject,
+					resourceName
+						? {
+								color: resourceColors[resourceName.subtype as keyof typeof resourceColors],
+							}
+						: undefined
 				)
 			)
-
-			if (frame.physicalObject?.geometryType) {
-				objects.push(
-					new WorldObject(
-						`${frameName} ${frame.physicalObject.geometryType.case}`,
-						frame.physicalObject.center,
-						frameName,
-						frame.physicalObject.geometryType,
-						resourceName
-							? {
-									color: resourceColors[resourceName.subtype as keyof typeof resourceColors],
-								}
-							: undefined
-					)
-				)
-			}
 		}
 
 		return objects

--- a/src/lib/hooks/useGeometries.svelte.ts
+++ b/src/lib/hooks/useGeometries.svelte.ts
@@ -83,13 +83,13 @@ export const provideGeometries = (partID: () => string) => {
 		for (const query of queries.current) {
 			if (!query.data) continue
 
-			for (const { center, label, geometryType } of query.data.geometries) {
+			for (const geometry of query.data.geometries) {
 				const resourceName = resourceNames.current.find((item) => item.name === query.data.name)
 				const worldObject = new WorldObject(
-					label ? label : 'Unnamed geometry',
-					center,
+					geometry.label ? geometry.label : `${query.data.name} geometry`,
+					undefined,
 					query.data.name,
-					geometryType,
+					geometry,
 					resourceName
 						? { color: resourceColors[resourceName.subtype as keyof typeof resourceColors] }
 						: undefined

--- a/src/lib/hooks/usePointclouds.svelte.ts
+++ b/src/lib/hooks/usePointclouds.svelte.ts
@@ -59,7 +59,7 @@ export const providePointclouds = (partID: () => string) => {
 						`${name}:pointcloud`,
 						undefined,
 						name,
-						{ case: 'points', value: positions },
+						{ center: undefined, geometryType: { case: 'points', value: positions } },
 						colors ? { colors } : undefined
 					)
 				},

--- a/src/lib/hooks/useStaticGeometries.svelte.ts
+++ b/src/lib/hooks/useStaticGeometries.svelte.ts
@@ -39,7 +39,7 @@ export const provideStaticGeometries = () => {
 				createGeometry({
 					case: 'box',
 					value: { dimsMm: { x: 100, y: 100, z: 100 } },
-				}).geometryType
+				})
 			)
 
 			geometries.push(structuredClone(object))


### PR DESCRIPTION
### Overview

Separating geometries into another world object was a quick fix for not accounting for the "center" field. This is a better fix that reintegrates them into the frame that they belong to.