### PR TITLE
Feat add interaction layer trait

### DIFF
--- a/.changeset/curvy-boxes-dream.md
+++ b/.changeset/curvy-boxes-dream.md
@@ -1,0 +1,5 @@
+---
+'@viamrobotics/motion-tools': minor
+---
+
+add interaction layer trait

--- a/src/lib/components/PCD.svelte
+++ b/src/lib/components/PCD.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import type { ConfigurableTrait, Entity } from 'koota'
 
+	import type { InteractionLayerValue } from '$lib/ecs/traits'
+
 	import { createBufferGeometry } from '$lib/attribute'
 	import { ColorFormat } from '$lib/buf/draw/v1/metadata_pb'
 	import { traits, useWorld } from '$lib/ecs'
@@ -8,12 +10,15 @@
 
 	interface Props {
 		data: Uint8Array
-		name?: string
-		renderOrder?: number
-		oncreate?: (positions: Float32Array, colors: Uint8Array | undefined) => void
+		options?: {
+			name?: string
+			renderOrder?: number
+			interactionLayers?: InteractionLayerValue[]
+			oncreate?: (positions: Float32Array, colors: Uint8Array | undefined) => void
+		}
 	}
 
-	let { data, name, renderOrder, oncreate }: Props = $props()
+	let { data, options }: Props = $props()
 
 	const world = useWorld()
 
@@ -24,18 +29,21 @@
 			const geometry = createBufferGeometry(positions, { colors, colorFormat: ColorFormat.RGB })
 
 			const entityTraits: ConfigurableTrait[] = [
-				traits.Name(name ?? 'Random points'),
+				traits.Name(options?.name ?? 'Random points'),
 				traits.Points,
 				traits.BufferGeometry(geometry),
 			]
 
-			if (renderOrder) {
-				entityTraits.push(traits.RenderOrder(renderOrder))
+			if (options?.renderOrder) {
+				entityTraits.push(traits.RenderOrder(options.renderOrder))
+			}
+			if (options?.interactionLayers?.includes('selectTool')) {
+				entityTraits.push(traits.SelectToolInteractionLayer)
 			}
 
 			entity = world.spawn(...entityTraits)
 
-			oncreate?.(positions, colors ?? undefined)
+			options?.oncreate?.(positions, colors ?? undefined)
 		})
 
 		return () => {

--- a/src/lib/components/PCD.svelte
+++ b/src/lib/components/PCD.svelte
@@ -10,15 +10,13 @@
 
 	interface Props {
 		data: Uint8Array
-		options?: {
-			name?: string
-			renderOrder?: number
-			interactionLayers?: InteractionLayerValue[]
-			oncreate?: (positions: Float32Array, colors: Uint8Array | undefined) => void
-		}
+		name?: string
+		renderOrder?: number
+		interactionLayers?: InteractionLayerValue[]
+		oncreate?: (positions: Float32Array, colors: Uint8Array | undefined) => void
 	}
 
-	let { data, options }: Props = $props()
+	let { data, name, renderOrder, interactionLayers, oncreate }: Props = $props()
 
 	const world = useWorld()
 
@@ -29,21 +27,21 @@
 			const geometry = createBufferGeometry(positions, { colors, colorFormat: ColorFormat.RGB })
 
 			const entityTraits: ConfigurableTrait[] = [
-				traits.Name(options?.name ?? 'Random points'),
+				traits.Name(name ?? 'Random points'),
 				traits.Points,
 				traits.BufferGeometry(geometry),
 			]
 
-			if (options?.renderOrder) {
-				entityTraits.push(traits.RenderOrder(options.renderOrder))
+			if (renderOrder) {
+				entityTraits.push(traits.RenderOrder(renderOrder))
 			}
-			if (options?.interactionLayers?.includes('selectTool')) {
+			if (interactionLayers?.includes('selectTool')) {
 				entityTraits.push(traits.SelectToolInteractionLayer)
 			}
 
 			entity = world.spawn(...entityTraits)
 
-			options?.oncreate?.(positions, colors ?? undefined)
+			oncreate?.(positions, colors ?? undefined)
 		})
 
 		return () => {

--- a/src/lib/components/Selection/Ellipse.svelte
+++ b/src/lib/components/Selection/Ellipse.svelte
@@ -171,6 +171,7 @@
 
 		for (const pointsEntity of world.query(
 			traits.Points,
+			traits.SelectToolInteractionLayer,
 			Not(selectionTraits.SelectionEnclosedPoints)
 		)) {
 			const geometry = pointsEntity.get(traits.BufferGeometry)

--- a/src/lib/components/Selection/Lasso.svelte
+++ b/src/lib/components/Selection/Lasso.svelte
@@ -153,6 +153,7 @@
 
 		for (const pointsEntity of world.query(
 			traits.Points,
+			traits.SelectToolInteractionLayer,
 			Not(selectionTraits.SelectionEnclosedPoints)
 		)) {
 			const geometry = pointsEntity.get(traits.BufferGeometry)

--- a/src/lib/ecs/traits.ts
+++ b/src/lib/ecs/traits.ts
@@ -164,6 +164,12 @@ export const DotSize = trait(() => 10)
 export const ReferenceFrame = trait(() => true)
 
 /**
+ * Interaction layers for entities
+ */
+export type InteractionLayerValue = 'selectTool'
+export const SelectToolInteractionLayer = trait(() => true)
+
+/**
  * This entity can be safetly removed from the scene by the user
  */
 export const Removable = trait(() => true)

--- a/src/routes/select/+page.svelte
+++ b/src/routes/select/+page.svelte
@@ -13,6 +13,6 @@
 {#await createRandomPcdBinary(10_000, 1) then data}
 	<PCD
 		{data}
-		options={{ interactionLayers: ['selectTool'] }}
+		interactionLayers={['selectTool']}
 	/>
 {/await}

--- a/src/routes/select/+page.svelte
+++ b/src/routes/select/+page.svelte
@@ -11,5 +11,8 @@
 />
 
 {#await createRandomPcdBinary(10_000, 1) then data}
-	<PCD {data} />
+	<PCD
+		{data}
+		options={{ interactionLayers: ['selectTool'] }}
+	/>
 {/await}


### PR DESCRIPTION
# Description
https://viam.atlassian.net/browse/APP-15947
This PR allows us to specify if an entity is eligible for lassoing, this will allow sanding to add multiple PCDs to their scene without having to worry about selecting points on the non-hardtop pcd

# Testing
- ran locally with the /selection endpoint and saw we can turn on and off select-ability for PCDs 

https://github.com/user-attachments/assets/b606d814-b843-4859-85fd-84609bbb4945

