### PR TITLE
Fix use screen space ellipse

### DIFF
--- a/.changeset/ripe-brooms-joke.md
+++ b/.changeset/ripe-brooms-joke.md
@@ -1,0 +1,5 @@
+---
+'@viamrobotics/motion-tools': patch
+---
+
+fix: use screen sapce for ellipse select

--- a/src/lib/components/Selection/Ellipse.svelte
+++ b/src/lib/components/Selection/Ellipse.svelte
@@ -46,6 +46,7 @@
 			traits.LinePositions(new Float32Array([x, y, 0])),
 			selectionTraits.StartPoint({ x, y }),
 			traits.LineWidth(1.5),
+			traits.ScreenSpace,
 			traits.RenderOrder(999),
 			traits.Material({ depthTest: false }),
 			traits.Color({ r: 1, g: 0, b: 0 }),


### PR DESCRIPTION
# Description

We were not using screen space line widthing for ellipse select, this makes ellipse lines almost invisible when the camera is far away, this change fixes to use screen space like the lasso

# Testing
- ran locally and saw ellipse even from far away cam positions

https://github.com/user-attachments/assets/83db382f-75a4-4146-b2fb-5ccfff5488ba


