### PR TITLE
wire up RenderOrder and Material traits, add depthWrite support

### DIFF
--- a/.changeset/grumpy-points-go.md
+++ b/.changeset/grumpy-points-go.md
@@ -1,0 +1,5 @@
+---
+'@viamrobotics/motion-tools': minor
+---
+
+wire up RenderOrder and Material traits, add depthWrite support

--- a/src/lib/components/Entities/Points.svelte
+++ b/src/lib/components/Entities/Points.svelte
@@ -33,6 +33,8 @@
 	const opacity = useTrait(() => entity, traits.Opacity)
 	const invisible = useTrait(() => entity, traits.Invisible)
 	const showAxesHelper = useTrait(() => entity, traits.ShowAxesHelper)
+	const renderOrder = useTrait(() => entity, traits.RenderOrder)
+	const materialProps = useTrait(() => entity, traits.Material)
 
 	const pointSize = $derived(
 		entityPointSize.current ? entityPointSize.current * 0.001 : settings.current.pointSize
@@ -91,6 +93,11 @@
 	})
 
 	$effect.pre(() => {
+		material.depthTest = materialProps.current?.depthTest ?? true
+		material.depthWrite = materialProps.current?.depthWrite ?? true
+	})
+
+	$effect.pre(() => {
 		if (pose.current) {
 			poseToObject3d(pose.current, points)
 		}
@@ -124,6 +131,7 @@
 			name={entity}
 			bvh={{ maxDepth: 40, maxLeafSize: 20 }}
 			visible={invisible.current !== true}
+			renderOrder={renderOrder.current}
 			{...events}
 		>
 			<T is={geometry.current} />

--- a/src/lib/components/PCD.svelte
+++ b/src/lib/components/PCD.svelte
@@ -12,11 +12,13 @@
 		data: Uint8Array
 		name?: string
 		renderOrder?: number
+		depthTest?: boolean
+		depthWrite?: boolean
 		interactionLayers?: InteractionLayerValue[]
 		oncreate?: (positions: Float32Array, colors: Uint8Array | undefined) => void
 	}
 
-	let { data, name, renderOrder, interactionLayers, oncreate }: Props = $props()
+	let { data, name, renderOrder, depthTest, depthWrite, interactionLayers, oncreate }: Props = $props()
 
 	const world = useWorld()
 
@@ -37,6 +39,9 @@
 
 			if (renderOrder) {
 				entityTraits.push(traits.RenderOrder(renderOrder))
+			}
+			if (depthTest !== undefined || depthWrite !== undefined) {
+				entityTraits.push(traits.Material({ depthTest: depthTest ?? true, depthWrite: depthWrite ?? true }))
 			}
 			if (interactionLayers?.includes('selectTool')) {
 				entityTraits.push(traits.SelectToolInteractionLayer)

--- a/src/lib/components/PCD.svelte
+++ b/src/lib/components/PCD.svelte
@@ -18,7 +18,8 @@
 		oncreate?: (positions: Float32Array, colors: Uint8Array | undefined) => void
 	}
 
-	let { data, name, renderOrder, depthTest, depthWrite, interactionLayers, oncreate }: Props = $props()
+	let { data, name, renderOrder, depthTest, depthWrite, interactionLayers, oncreate }: Props =
+		$props()
 
 	const world = useWorld()
 
@@ -41,7 +42,9 @@
 				entityTraits.push(traits.RenderOrder(renderOrder))
 			}
 			if (depthTest !== undefined || depthWrite !== undefined) {
-				entityTraits.push(traits.Material({ depthTest: depthTest ?? true, depthWrite: depthWrite ?? true }))
+				entityTraits.push(
+					traits.Material({ depthTest: depthTest ?? true, depthWrite: depthWrite ?? true })
+				)
 			}
 			if (interactionLayers?.includes('selectTool')) {
 				entityTraits.push(traits.SelectToolInteractionLayer)

--- a/src/lib/ecs/traits.ts
+++ b/src/lib/ecs/traits.ts
@@ -68,6 +68,7 @@ export const Color = trait({ r: 0, g: 0, b: 0 })
  */
 export const Material = trait({
 	depthTest: false,
+	depthWrite: true,
 })
 
 export const DepthTest = trait(() => true)


### PR DESCRIPTION
## Summary
- Add `depthWrite` support to the `Material` trait
- Add `renderOrder`, `depthTest`, and `depthWrite` support to `Points.svelte`
- Expose `depthTest` and `depthWrite` props on `PCD.svelte`

## Motivation: went to use `renderOrder`, `depthTest`, and `depthWrite` for PCDs and points but they weren't supported yet

[slack thread](https://viaminc.slack.com/archives/C071CRAU7EJ/p1777406826162839) containing some context