### PR TITLE
Capture save keyboard event before hitting input bindings

### DIFF
--- a/.changeset/jolly-numbers-hug.md
+++ b/.changeset/jolly-numbers-hug.md
@@ -1,0 +1,5 @@
+---
+'@viamrobotics/motion-tools': patch
+---
+
+Capture save keyboard event before hitting input bindings

--- a/src/lib/components/InputBindings.svelte
+++ b/src/lib/components/InputBindings.svelte
@@ -85,7 +85,7 @@
 			const dt = delta * 1000
 
 			// Disallow keyboard navigation if the user is holding down the meta key
-			if (keyboard.key('meta').pressed) {
+			if (keyboard.key('meta').pressed || keyboard.key('control').pressed) {
 				return
 			}
 

--- a/src/lib/components/overlay/LiveUpdatesBanner.svelte
+++ b/src/lib/components/overlay/LiveUpdatesBanner.svelte
@@ -13,7 +13,7 @@
 </script>
 
 <svelte:window
-	onkeydown={(event) => {
+	onkeydowncapture={(event) => {
 		if (event.metaKey && event.key.toLowerCase() === 's') {
 			event.preventDefault()
 			event.stopImmediatePropagation()


### PR DESCRIPTION
Fixes uncontrolled camera movement when saving