### PR TITLE
fix: swap dark:text-black for dark:text-white on details panel

### DIFF
--- a/.changeset/details-panel-dark-text.md
+++ b/.changeset/details-panel-dark-text.md
@@ -1,0 +1,7 @@
+---
+'@viamrobotics/motion-tools': patch
+---
+
+Fix unreadable text in the Details panel under dark mode by swapping
+`dark:text-black` for `dark:text-white` on the panel container so child
+text contrasts against dark surroundings rather than disappearing.

--- a/src/lib/components/overlay/Details.svelte
+++ b/src/lib/components/overlay/Details.svelte
@@ -338,7 +338,7 @@
 {#if entity}
 	<div
 		id="details-panel"
-		class="border-medium bg-extralight absolute top-0 right-0 z-4 m-2 w-70 border p-2 text-xs dark:text-black"
+		class="border-medium bg-extralight absolute top-0 right-0 z-4 m-2 w-70 border p-2 text-xs dark:text-white"
 		use:draggable={{
 			bounds: 'body',
 			handle: dragElement,


### PR DESCRIPTION
The Details panel container hardcoded dark:text-black, which forced child text to black in dark mode and produced unreadable contrast for consumer apps that render the visualizer against a dark surface.