### PR TITLE
Feat add color prop pcd

### DIFF
--- a/.changeset/eager-bushes-drop.md
+++ b/.changeset/eager-bushes-drop.md
@@ -1,0 +1,5 @@
+---
+'@viamrobotics/motion-tools': minor
+---
+
+add pcd color prop

--- a/src/lib/components/PCD.svelte
+++ b/src/lib/components/PCD.svelte
@@ -50,25 +50,15 @@
 			if (renderOrder) {
 				entityTraits.push(traits.RenderOrder(renderOrder))
 			}
-			const materialOptions: {
-				depthTest?: boolean
-				depthWrite?: boolean
-				color?: number | string
-			} = {}
-			if (depthTest !== undefined) {
-				materialOptions.depthTest = depthTest
-			}
-			if (depthWrite !== undefined) {
-				materialOptions.depthWrite = depthWrite
-			}
 
+			if (depthTest !== undefined || depthWrite !== undefined) {
+				entityTraits.push(
+					traits.Material({ depthTest: depthTest ?? true, depthWrite: depthWrite ?? true })
+				)
+			}
 			if (color !== undefined) {
 				geometry.deleteAttribute('color')
 				entityTraits.push(traits.Color({ r: color.r, g: color.g, b: color.b }))
-			}
-
-			if (Object.keys(materialOptions).length > 0) {
-				entityTraits.push(traits.Material(materialOptions))
 			}
 			if (interactionLayers?.includes('selectTool')) {
 				entityTraits.push(traits.SelectToolInteractionLayer)

--- a/src/lib/components/PCD.svelte
+++ b/src/lib/components/PCD.svelte
@@ -14,12 +14,21 @@
 		renderOrder?: number
 		depthTest?: boolean
 		depthWrite?: boolean
+		color?: { r: number; g: number; b: number }
 		interactionLayers?: InteractionLayerValue[]
 		oncreate?: (positions: Float32Array, colors: Uint8Array | undefined) => void
 	}
 
-	let { data, name, renderOrder, depthTest, depthWrite, interactionLayers, oncreate }: Props =
-		$props()
+	let {
+		data,
+		name,
+		renderOrder,
+		depthTest,
+		depthWrite,
+		color,
+		interactionLayers,
+		oncreate,
+	}: Props = $props()
 
 	const world = useWorld()
 
@@ -41,10 +50,25 @@
 			if (renderOrder) {
 				entityTraits.push(traits.RenderOrder(renderOrder))
 			}
-			if (depthTest !== undefined || depthWrite !== undefined) {
-				entityTraits.push(
-					traits.Material({ depthTest: depthTest ?? true, depthWrite: depthWrite ?? true })
-				)
+			const materialOptions: {
+				depthTest?: boolean
+				depthWrite?: boolean
+				color?: number | string
+			} = {}
+			if (depthTest !== undefined) {
+				materialOptions.depthTest = depthTest
+			}
+			if (depthWrite !== undefined) {
+				materialOptions.depthWrite = depthWrite
+			}
+
+			if (color !== undefined) {
+				geometry.deleteAttribute('color')
+				entityTraits.push(traits.Color({ r: color.r, g: color.g, b: color.b }))
+			}
+
+			if (Object.keys(materialOptions).length > 0) {
+				entityTraits.push(traits.Material(materialOptions))
 			}
 			if (interactionLayers?.includes('selectTool')) {
 				entityTraits.push(traits.SelectToolInteractionLayer)


### PR DESCRIPTION
# Description
for this https://viam.atlassian.net/browse/APP-16320 we want to expose a way for users to override PCD colors using props. This pr exposes a way to do that via props

# Testing
- ran SOW app with linked version and made sure I could override the PCD component color with the color prop and when absent showed the real pcd color
<img width="1408" height="761" alt="Screenshot 2026-05-05 at 2 36 52 PM" src="https://github.com/user-attachments/assets/f59f9cea-7f15-4aa1-97c8-96634b21ada2" />
