### PR TITLE
fix

### DIFF
--- a/.changeset/clever-mice-itch.md
+++ b/.changeset/clever-mice-itch.md
@@ -1,0 +1,5 @@
+---
+'@viamrobotics/motion-tools': patch
+---
+
+hotfix: Bail out line dot effect when positions is undefined

--- a/src/lib/components/Entities/LineDots.svelte
+++ b/src/lib/components/Entities/LineDots.svelte
@@ -40,6 +40,7 @@
 	})
 
 	$effect(() => {
+		if (!positions) return
 		for (let i = 0, l = positions.length; i < l; i += 3) {
 			const dotIndex = i / 3
 			const instance = mesh.addInstance(geometryID)


### PR DESCRIPTION
@micheal-parks we caught this with updating/re-rendering lines, where the line dots would receive an `undefined` `positions` prop and throw and error breaking the page.