### PR TITLE
Reduce logs memory and CPU consumption

### DIFF
--- a/.changeset/dull-walls-relax.md
+++ b/.changeset/dull-walls-relax.md
@@ -1,0 +1,5 @@
+---
+'@viamrobotics/motion-tools': patch
+---
+
+Reduce logs memory and CPU consumption

--- a/src/lib/components/overlay/FloatingPanel.svelte
+++ b/src/lib/components/overlay/FloatingPanel.svelte
@@ -89,11 +89,20 @@
 			</div>
 		</div>
 
+		<!--
+			Skip rendering the body subtree while collapsed. zag-js controls
+			visibility via attributes (the panel chrome stays mounted), but the
+			children — which can be heavy, e.g. the 200-row Logs each block —
+			don't need to react to upstream state when the user can't see them.
+			Children mount fresh on open.
+		-->
 		<div
 			{...api.getBodyProps()}
 			class="relative h-[calc(100%-33px)]"
 		>
-			{@render children()}
+			{#if isOpen}
+				{@render children()}
+			{/if}
 		</div>
 
 		{#if resizable}

--- a/src/lib/components/overlay/FloatingPanel.svelte
+++ b/src/lib/components/overlay/FloatingPanel.svelte
@@ -92,8 +92,7 @@
 		<!--
 			Skip rendering the body subtree while collapsed. zag-js controls
 			visibility via attributes (the panel chrome stays mounted), but the
-			children — which can be heavy, e.g. the 200-row Logs each block —
-			don't need to react to upstream state when the user can't see them.
+			children don't need to react to upstream state when the user can't see them.
 			Children mount fresh on open.
 		-->
 		<div

--- a/src/lib/ecs/hierarchy.ts
+++ b/src/lib/ecs/hierarchy.ts
@@ -24,14 +24,24 @@ export const parentTraits = (name: string | undefined): ConfigurableTrait[] => {
  * Set or clear an entity's parent. Strips any existing `ChildOf` or `Orphan`,
  * then writes `Orphan(name)` (the resolver converts it to `ChildOf` on the
  * next reactive flush). Pass `undefined` or `'world'` to detach to root.
+ *
+ * Short-circuits when the effective parent name (via resolved `ChildOf` or
+ * pending `Orphan`) already matches `name`. Network-backed reconcilers call
+ * this every refetch tick on stable entities; the demote-then-re-resolve
+ * dance otherwise flips `useParentName` to `undefined` and back, remounting
+ * every `<Portal id={parent.current}>` subtree per tick.
  */
 export const setParent = (entity: Entity, name: string | undefined): void => {
+	const desired = !name || name === 'world' ? undefined : name
 	const target = entity.targetFor(ChildOf)
+	const current = (target?.isAlive() ? target.get(Name) : undefined) ?? entity.get(Orphan)
+	if (current === desired) return
+
 	if (target) entity.remove(ChildOf(target))
 	entity.remove(Orphan)
 
-	if (!name || name === 'world') return
-	entity.add(Orphan(name))
+	if (desired === undefined) return
+	entity.add(Orphan(desired))
 }
 
 /** The parent entity, or `undefined` at the world root or while orphaned. */

--- a/src/lib/hooks/useLogs.svelte.ts
+++ b/src/lib/hooks/useLogs.svelte.ts
@@ -20,19 +20,37 @@ interface Context {
 	add(message: string, level?: Level): void
 }
 
+const MAX_LOGS = 200
+
 export const provideLogs = () => {
-	const logs = $state<Log[]>([])
-	const warnings = $state<Log[]>([])
-	const errors = $state<Log[]>([])
+	// Plain insertion-ordered Map keyed by `${level}|${timestamp}|${message}`
+	// drives storage; a single `$state` version counter drives reactivity.
+	// Hot path is `Map.set` (or in-place `count++`) plus `version++` — no
+	// array allocation per add. The display arrays are materialized lazily
+	// in `$derived.by`, so a closed logs panel costs nothing.
+	const entries = new Map<string, Log>()
+	let version = $state(0)
 
 	const intl = new Intl.DateTimeFormat('en-US', {
 		dateStyle: 'short',
 		timeStyle: 'short',
 	})
 
+	const dedupKey = (timestamp: string, level: Level, message: string): string =>
+		`${level}\0${timestamp}\0${message}`
+
+	const all = $derived.by(() => {
+		void version
+		const out = [...entries.values()]
+		out.reverse()
+		return out
+	})
+	const errors = $derived(all.filter((l) => l.level === 'error'))
+	const warnings = $derived(all.filter((l) => l.level === 'warn'))
+
 	setContext<Context>(key, {
 		get current() {
-			return logs
+			return all
 		},
 		get errors() {
 			return errors
@@ -43,39 +61,26 @@ export const provideLogs = () => {
 		add(message, level = 'info') {
 			untrack(() => {
 				const timestamp = intl.format(Date.now())
-				const match = logs.find(
-					(log) => log.message === message && log.level === level && log.timestamp === timestamp
-				)
+				const k = dedupKey(timestamp, level, message)
+				const match = entries.get(k)
 
 				if (match) {
 					match.count += 1
 				} else {
-					const log: Log = {
-						timestamp,
+					entries.set(k, {
+						uuid: MathUtils.generateUUID(),
 						message,
 						count: 1,
 						level,
-						uuid: MathUtils.generateUUID(),
-					}
-
-					logs.unshift(log)
-
-					if (level === 'error') {
-						errors.unshift(log)
-					} else if (level === 'warn') {
-						warnings.unshift(log)
+						timestamp,
+					})
+					if (entries.size > MAX_LOGS) {
+						const oldestKey = entries.keys().next().value
+						if (oldestKey !== undefined) entries.delete(oldestKey)
 					}
 				}
 
-				if (logs.length > 200) {
-					const log = logs.pop()
-
-					if (log?.level === 'error') {
-						errors.splice(errors.indexOf(log), 1)
-					} else if (log?.level === 'warn') {
-						warnings.splice(warnings.indexOf(log), 1)
-					}
-				}
+				version++
 			})
 		},
 	})


### PR DESCRIPTION
After profiling with claude I discovered that the current logs setup is eating a shocking amount of CPU and memory. It's likely causing a lot of performance issues I'm witnessing on the Quest headset. This PR substantially reduces the problem, with the following graph representing profiles before / after:

<img width="411" height="202" alt="Screenshot 2026-05-08 at 11 17 39" src="https://github.com/user-attachments/assets/7d871b70-318d-4ae5-aecf-96f5bb18b068" />


Details of the changes are in comments.