### PR TITLE
add generic component to useGeometries

### DIFF
--- a/.changeset/silent-frames-render.md
+++ b/.changeset/silent-frames-render.md
@@ -1,0 +1,5 @@
+---
+'@viamrobotics/motion-tools': patch
+---
+
+Fetch geometries from generic components

--- a/src/lib/hooks/useGeometries.svelte.ts
+++ b/src/lib/hooks/useGeometries.svelte.ts
@@ -1,4 +1,11 @@
-import { ArmClient, BaseClient, CameraClient, GantryClient, GripperClient } from '@viamrobotics/sdk'
+import {
+	ArmClient,
+	BaseClient,
+	CameraClient,
+	GantryClient,
+	GenericComponentClient,
+	GripperClient,
+} from '@viamrobotics/sdk'
 import {
 	createResourceClient,
 	createResourceQuery,
@@ -37,6 +44,7 @@ export const provideGeometries = (partID: () => string) => {
 	const cameras = useResourceNames(partID, 'camera')
 	const grippers = useResourceNames(partID, 'gripper')
 	const gantries = useResourceNames(partID, 'gantry')
+	const generics = useResourceNames(partID, 'generic')
 
 	const settings = useSettings()
 	const { refreshRates } = $derived(settings.current)
@@ -57,6 +65,11 @@ export const provideGeometries = (partID: () => string) => {
 	)
 	const gantryClients = $derived(
 		gantries.current.map((gantry) => createResourceClient(GantryClient, partID, () => gantry.name))
+	)
+	const genericClients = $derived(
+		generics.current.map((generic) =>
+			createResourceClient(GenericComponentClient, partID, () => generic.name)
+		)
 	)
 
 	const interval = $derived(refreshRates[RefreshRates.poses])
@@ -96,6 +109,12 @@ export const provideGeometries = (partID: () => string) => {
 				[client.current?.name, createResourceQuery(client, 'getGeometries', () => options)] as const
 		)
 	)
+	const genericQueries = $derived(
+		genericClients.map(
+			(client) =>
+				[client.current?.name, createResourceQuery(client, 'getGeometries', () => options)] as const
+		)
+	)
 
 	const queries = $derived([
 		...armQueries,
@@ -103,6 +122,7 @@ export const provideGeometries = (partID: () => string) => {
 		...gripperQueries,
 		...cameraQueries,
 		...gantryQueries,
+		...genericQueries,
 	])
 
 	$effect(() => {

--- a/src/lib/hooks/useGeometries.svelte.ts
+++ b/src/lib/hooks/useGeometries.svelte.ts
@@ -67,9 +67,9 @@ export const provideGeometries = (partID: () => string) => {
 		gantries.current.map((gantry) => createResourceClient(GantryClient, partID, () => gantry.name))
 	)
 	const genericClients = $derived(
-		generics.current.map((generic) =>
-			createResourceClient(GenericComponentClient, partID, () => generic.name)
-		)
+		generics.current
+			.filter((generic) => generic.type === 'component')
+			.map((generic) => createResourceClient(GenericComponentClient, partID, () => generic.name))
 	)
 
 	const interval = $derived(refreshRates[RefreshRates.poses])


### PR DESCRIPTION
merged a change to rdk that adds GetGeometries to generic components (seems like a bug that it was not implemented) and now closing the loop so the 3d scene tab can visualize generic components with geometries. should let us do very simple things like make obstacles out of meshes that aren't implemented as "grippers" for no reason

tested this locally and it does work with the rdk changes (i forgot to take a screenshot before shutting everything off but trust me it works)

rdk pr: https://github.com/viamrobotics/rdk/pull/5999