### PR TITLE
assign 3d models current after all clients resolve

### DIFF
--- a/.changeset/lovely-drinks-tease.md
+++ b/.changeset/lovely-drinks-tease.md
@@ -1,0 +1,5 @@
+---
+'@viamrobotics/motion-tools': patch
+---
+
+fix: set 3d models current in outer loop

--- a/src/lib/hooks/use3DModels.svelte.ts
+++ b/src/lib/hooks/use3DModels.svelte.ts
@@ -68,12 +68,12 @@ export const provide3DModels = (partID: () => string) => {
 						}
 					})
 				}
-				current = next
 			} catch (error) {
 				// some arms may not implement this api yet
 				console.warn(`${client.current.name} returned an error: ${error} when getting 3D models`)
 			}
 		}
+		current = next
 	}
 
 	$effect(() => {


### PR DESCRIPTION
# Description 
in this thread https://viaminc.slack.com/archives/C071CRAU7EJ/p1778765771671389

we saw issue when visualizing multiple 3d models for different resources in the same scene, I was setting current in the inner loop so it would update for the first arm but just add more keys on subsequent sets (which svelte was not reactive to since it is a state.raw). This worked fine on other real arms since the geometry labels are set by the module (so base_top is always xarm:base_top for all arms) the fake and simulated change the label prefix to match the frame e.x. arm1:base_top and arm2:base_top

This PR sets current outside of the loop after the full object is accumulated

# Testing 
- tested on Brandon's example with sim arms 
<img width="998" height="931" alt="Screenshot 2026-05-14 at 2 56 01 PM" src="https://github.com/user-attachments/assets/a74b661b-02c7-46c1-a676-f64c69588d21" />
- tested on a real robot with 2 arms 
<img width="1533" height="1097" alt="Screenshot 2026-05-14 at 2 58 35 PM" src="https://github.com/user-attachments/assets/d2e9408c-617d-41a1-9302-e8ced3d3f33f" />

