### PR TITLE
Fix parenting on `GetGeometries` entities

### DIFF
--- a/.changeset/good-trainers-help.md
+++ b/.changeset/good-trainers-help.md
@@ -1,0 +1,5 @@
+---
+"@viamrobotics/motion-tools": patch
+---
+
+Fix parenting on `GetGeometries` entities

--- a/src/lib/components/App.svelte
+++ b/src/lib/components/App.svelte
@@ -8,6 +8,7 @@
 	import { PortalTarget } from '@threlte/extras'
 	import { useXR } from '@threlte/xr'
 	import { provideToast, ToastContainer } from '@viamrobotics/prime-core'
+	import { ThemeUtils } from 'svelte-tweakpane-ui'
 
 	import type { CameraPose } from '$lib/hooks/useControls.svelte'
 
@@ -90,10 +91,6 @@
 	const currentRobotCameraWidgets = $derived(settings.current.openCameraWidgets[partID] || [])
 	const { isPresenting } = useXR()
 
-	$effect(() => {
-		environment.current.inputBindingsEnabled = inputBindingsEnabled
-	})
-
 	createPartIDContext(() => partID)
 	provideDrawConnectionConfig(() => drawConnectionConfig)
 	provideWeblabs()
@@ -106,8 +103,17 @@
 		() => localConfigProps
 	)
 
-	$effect.pre(() => {
+	$effect(() => {
+		environment.current.inputBindingsEnabled = inputBindingsEnabled
 		environment.current.isStandalone = !localConfigProps
+	})
+
+	$effect(() => {
+		ThemeUtils.setGlobalDefaultTheme({
+			...ThemeUtils.presets.light,
+			baseBackgroundColor: '#fbfbfc',
+			baseShadowColor: 'transparent',
+		})
 	})
 </script>
 

--- a/src/lib/components/overlay/Details.svelte
+++ b/src/lib/components/overlay/Details.svelte
@@ -2,7 +2,6 @@
 	module
 	lang="ts"
 >
-	import { ThemeUtils } from 'svelte-tweakpane-ui'
 	import { BufferAttribute, Euler, MathUtils, Quaternion } from 'three'
 
 	import { OrientationVector } from '$lib/three/OrientationVector'
@@ -280,12 +279,6 @@
 			2
 		)
 	}
-
-	ThemeUtils.setGlobalDefaultTheme({
-		...ThemeUtils.presets.light,
-		baseBackgroundColor: '#fbfbfc',
-		baseShadowColor: 'transparent',
-	})
 </script>
 
 {#snippet ImmutableField({

--- a/src/lib/ecs/traits.ts
+++ b/src/lib/ecs/traits.ts
@@ -271,7 +271,9 @@ export const updateGeometryTrait = (entity: Entity, geometry?: ViamGeometry) => 
 		}
 	} else if (geometry.geometryType.case === 'mesh') {
 		if (entity.has(BufferGeometry)) {
+			const old = entity.get(BufferGeometry)
 			entity.set(BufferGeometry, parsePlyInput(geometry.geometryType.value.mesh))
+			old?.dispose()
 		} else {
 			entity.remove(Box, Sphere, Capsule)
 			entity.add(BufferGeometry(parsePlyInput(geometry.geometryType.value.mesh)))

--- a/src/lib/hooks/useGeometries.svelte.ts
+++ b/src/lib/hooks/useGeometries.svelte.ts
@@ -13,13 +13,13 @@ import {
 } from '@viamrobotics/svelte-sdk'
 import { type ConfigurableTrait, type Entity } from 'koota'
 import { getContext, setContext, untrack } from 'svelte'
-import { Color } from 'three'
+import { Color, Matrix4 } from 'three'
 
 import { resourceColors } from '$lib/color'
 import { RefetchRates } from '$lib/components/overlay/RefreshRate.svelte'
 import { hierarchy, traits, useWorld } from '$lib/ecs'
 import { updateGeometryTrait } from '$lib/ecs/traits'
-import { createPose, isPoseEqual } from '$lib/transform'
+import { createPose, poseToMatrix } from '$lib/transform'
 
 import { useEnvironment } from './useEnvironment.svelte'
 import { useLogs } from './useLogs.svelte'
@@ -33,6 +33,7 @@ interface Context {
 }
 
 const colorUtil = new Color()
+const tempMatrix = new Matrix4()
 
 export const provideGeometries = (partID: () => string) => {
 	const environment = useEnvironment()
@@ -178,8 +179,11 @@ export const provideGeometries = (partID: () => string) => {
 
 						if (existing) {
 							hierarchy.setParent(existing, name)
-							if (!isPoseEqual(existing.get(traits.Center), center)) {
-								existing.set(traits.Center, center)
+							poseToMatrix(center, tempMatrix)
+							const matrix = existing.get(traits.Matrix)
+							if (matrix && !matrix.equals(tempMatrix)) {
+								matrix.copy(tempMatrix)
+								existing.changed(traits.Matrix)
 							}
 							updateGeometryTrait(existing, geometry)
 							continue
@@ -188,7 +192,7 @@ export const provideGeometries = (partID: () => string) => {
 						const entityTraits: ConfigurableTrait[] = [
 							...hierarchy.parentTraits(name),
 							traits.Name(label),
-							traits.Center(center),
+							traits.Matrix(poseToMatrix(center, new Matrix4())),
 							traits.GeometriesAPI,
 							traits.Geometry(geometry),
 						]

--- a/src/lib/three/OBBHelper.ts
+++ b/src/lib/three/OBBHelper.ts
@@ -56,9 +56,12 @@ const expandBoxByTransformedBox = (box: Box3, childBox: Box3, matrix: Matrix4) =
 
 export class OBBHelper extends LineSegments2 {
 	constructor(color = 0x000000, linewidth = 2) {
-		const edges = new EdgesGeometry(new BoxGeometry())
+		const boxGeometry = new BoxGeometry()
+		const edges = new EdgesGeometry(boxGeometry)
 		const geometry = new LineSegmentsGeometry()
 		geometry.setPositions(edges.getAttribute('position').array as Float32Array)
+		edges.dispose()
+		boxGeometry.dispose()
 
 		const material = new LineMaterial({
 			color,

--- a/src/lib/three/arrow.ts
+++ b/src/lib/three/arrow.ts
@@ -25,6 +25,8 @@ export const createArrowGeometry = (): BufferGeometry => {
 	headGeo.translate(0, tailLength + headLength * 0.5, 0)
 
 	const merged = mergeGeometries([tailGeometry, headGeo], true)
+	tailGeometry.dispose()
+	headGeo.dispose()
 	merged.computeVertexNormals()
 	merged.computeBoundingBox()
 	merged.computeBoundingSphere()


### PR DESCRIPTION
### Overview

We were most of the way there to supporting parenting to `Geometry` entities. The `Center` prop not informing local matrices was the missing step. This PR fixes that, with a few other drive by memory leak fixes. 