### PR TITLE
Dashboard cleanup

### DIFF
--- a/.changeset/busy-llamas-attack.md
+++ b/.changeset/busy-llamas-attack.md
@@ -1,0 +1,5 @@
+---
+"@viamrobotics/motion-tools": patch
+---
+
+Dashboard cleanup

--- a/src/lib/components/App.svelte
+++ b/src/lib/components/App.svelte
@@ -12,6 +12,7 @@
 
 	import type { CameraPose } from '$lib/hooks/useControls.svelte'
 
+	import Controls from '$lib/components/overlay/controls/Controls.svelte'
 	import Dashboard from '$lib/components/overlay/dashboard/Dashboard.svelte'
 	import Details from '$lib/components/overlay/Details.svelte'
 	import TreeContainer from '$lib/components/overlay/left-pane/TreeContainer.svelte'
@@ -147,6 +148,7 @@
 				<div {@attach domPortal(root)}>
 					<FileDrop />
 					<Dashboard {dashboard} />
+					<Controls />
 					<Details {details} />
 
 					{#if environment.current.isStandalone}

--- a/src/lib/components/App.svelte
+++ b/src/lib/components/App.svelte
@@ -10,8 +10,6 @@
 	import { provideToast, ToastContainer } from '@viamrobotics/prime-core'
 	import { ThemeUtils } from 'svelte-tweakpane-ui'
 
-	import type { CameraPose } from '$lib/hooks/useControls.svelte'
-
 	import Controls from '$lib/components/overlay/controls/Controls.svelte'
 	import Dashboard from '$lib/components/overlay/dashboard/Dashboard.svelte'
 	import Details from '$lib/components/overlay/Details.svelte'
@@ -19,6 +17,7 @@
 	import Settings from '$lib/components/overlay/settings/Settings.svelte'
 	import XR from '$lib/components/xr/XR.svelte'
 	import { provideWorld } from '$lib/ecs'
+	import { type CameraPose, provideCameraControls } from '$lib/hooks/useControls.svelte'
 	import {
 		type DrawConnectionConfig,
 		provideDrawConnectionConfig,
@@ -94,6 +93,7 @@
 	const currentFramePovWidgets = $derived(settings.current.openFramePovWidgets[partID] || [])
 	const { isPresenting } = useXR()
 
+	provideCameraControls(() => cameraPose)
 	createPartIDContext(() => partID)
 	provideDrawConnectionConfig(() => drawConnectionConfig)
 	provideWeblabs()
@@ -132,7 +132,7 @@
 		renderMode="on-demand"
 		dpr={[1, 2]}
 	>
-		<SceneProviders {cameraPose}>
+		<SceneProviders>
 			{#snippet children({ focus })}
 				<Scene>
 					{@render appChildren?.()}

--- a/src/lib/components/Camera.svelte
+++ b/src/lib/components/Camera.svelte
@@ -12,7 +12,7 @@
 {#if mode === 'perspective'}
 	<T.PerspectiveCamera
 		makeDefault
-		near={0.01}
+		near={0.001}
 		up={[0, 0, 1]}
 		oncreate={(ref) => {
 			ref.lookAt(0, 0, 0)

--- a/src/lib/components/CameraControls.svelte
+++ b/src/lib/components/CameraControls.svelte
@@ -15,12 +15,13 @@
 	const inputBindingsEnabled = $derived(environment.current.inputBindingsEnabled)
 </script>
 
-<Portal id="dashboard">
+<Portal id="controls">
 	<fieldset>
 		<Button
 			active
 			icon="camera-outline"
 			description="Reset camera"
+			tooltipLocation="left"
 			onclick={() => {
 				cameraControls.setInitialPose()
 			}}

--- a/src/lib/components/CameraControls.svelte
+++ b/src/lib/components/CameraControls.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
-	import { CameraControls, type CameraControlsRef, Gizmo, Portal } from '@threlte/extras'
+	import { CameraControls, type CameraControlsRef, Gizmo } from '@threlte/extras'
 	import { MathUtils } from 'three'
 
-	import Button from '$lib/components/overlay/dashboard/Button.svelte'
 	import { useCameraControls, useTransformControls } from '$lib/hooks/useControls.svelte'
 	import { useEnvironment } from '$lib/hooks/useEnvironment.svelte'
 
@@ -14,20 +13,6 @@
 
 	const inputBindingsEnabled = $derived(environment.current.inputBindingsEnabled)
 </script>
-
-<Portal id="controls">
-	<fieldset>
-		<Button
-			active
-			icon="camera-outline"
-			description="Reset camera"
-			tooltipLocation="left"
-			onclick={() => {
-				cameraControls.setInitialPose()
-			}}
-		/>
-	</fieldset>
-</Portal>
 
 <CameraControls
 	enabled={!transformControls.active}

--- a/src/lib/components/Focus.svelte
+++ b/src/lib/components/Focus.svelte
@@ -29,12 +29,13 @@
 	})
 </script>
 
-<Portal id="dashboard">
+<Portal id="controls">
 	<fieldset>
 		<Button
 			active
 			icon="camera-outline"
 			description="Reset camera"
+			tooltipLocation="left"
 			onclick={() => {
 				controls?.reset()
 			}}

--- a/src/lib/components/Focus.svelte
+++ b/src/lib/components/Focus.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
 	import { T } from '@threlte/core'
-	import { Gizmo, Portal, TrackballControls } from '@threlte/extras'
+	import { Gizmo, TrackballControls } from '@threlte/extras'
 	import { Box3, type Object3D, Vector3 } from 'three'
-	import { TrackballControls as ThreeTrackballControls } from 'three/examples/jsm/controls/TrackballControls.js'
 
-	import Button from '$lib/components/overlay/dashboard/Button.svelte'
+	import { useCameraControls } from '$lib/hooks/useControls.svelte'
 
 	import Camera from './Camera.svelte'
 
@@ -14,13 +13,13 @@
 
 	let { object3d }: Props = $props()
 
+	const cameraControls = useCameraControls()
+
 	const box = new Box3()
 	const vec = new Vector3()
 
 	let center = $state.raw<[number, number, number]>([0, 0, 0])
 	let size = $state.raw<[number, number, number]>([0, 0, 0])
-
-	let controls = $state.raw<ThreeTrackballControls>()
 
 	$effect.pre(() => {
 		box.setFromObject(object3d)
@@ -29,24 +28,10 @@
 	})
 </script>
 
-<Portal id="controls">
-	<fieldset>
-		<Button
-			active
-			icon="camera-outline"
-			description="Reset camera"
-			tooltipLocation="left"
-			onclick={() => {
-				controls?.reset()
-			}}
-		/>
-	</fieldset>
-</Portal>
-
 <Camera position={[size[0] + 1, size[0] + 1, size[0] + 1]}>
 	<TrackballControls
-		bind:ref={controls}
 		target={center}
+		oncreate={(ref) => cameraControls.set(ref)}
 	>
 		<Gizmo placement="bottom-right" />
 	</TrackballControls>

--- a/src/lib/components/MeasureTool/MeasureTool.svelte
+++ b/src/lib/components/MeasureTool/MeasureTool.svelte
@@ -84,6 +84,7 @@
 		<div class="flex">
 			<Button
 				active={enabled}
+				class="rounded-r-none"
 				icon="ruler"
 				description="{enabled ? 'Disable' : 'Enable'} measurement"
 				onclick={() => {
@@ -95,7 +96,7 @@
 					<Button
 						{...triggerProps}
 						active={enabled}
-						class="border-l-0"
+						class="rounded-l-none border-l-0"
 						icon="filter-sliders"
 						description="Measurement settings"
 					/>

--- a/src/lib/components/SceneProviders.svelte
+++ b/src/lib/components/SceneProviders.svelte
@@ -6,11 +6,7 @@
 	import { provideArmClient } from '$lib/hooks/useArmClient.svelte'
 	import { provideArmKinematics } from '$lib/hooks/useArmKinematics.svelte'
 	import { provideConfigFrames } from '$lib/hooks/useConfigFrames.svelte'
-	import {
-		type CameraPose,
-		provideCameraControls,
-		provideTransformControls,
-	} from '$lib/hooks/useControls.svelte'
+	import { provideTransformControls } from '$lib/hooks/useControls.svelte'
 	import { provideDrawAPI } from '$lib/hooks/useDrawAPI.svelte'
 	import { provideDrawService } from '$lib/hooks/useDrawService.svelte'
 	import { provideFrameEditSession } from '$lib/hooks/useFrameEditSession.svelte'
@@ -30,15 +26,13 @@
 	import { provideOrigin } from './xr/useOrigin.svelte'
 
 	interface Props {
-		cameraPose?: CameraPose
 		children: Snippet<[{ focus: boolean }]>
 	}
 
-	let { cameraPose, children }: Props = $props()
+	let { children }: Props = $props()
 
 	const partID = usePartID()
 
-	provideCameraControls(() => cameraPose)
 	provideTransformControls()
 	provideLogs()
 

--- a/src/lib/components/Selection/Ellipse.svelte
+++ b/src/lib/components/Selection/Ellipse.svelte
@@ -263,16 +263,18 @@
 
 		const currentControls = controls.current
 
-		const { minPolarAngle, maxPolarAngle } = currentControls
+		if ('minPolarAngle' in currentControls) {
+			const { minPolarAngle, maxPolarAngle } = currentControls
 
-		// Locks the camera to top down while this component is mounted
-		currentControls.polarAngle = 0
-		currentControls.minPolarAngle = 0
-		currentControls.maxPolarAngle = 0
+			// Locks the camera to top down while this component is mounted
+			currentControls.polarAngle = 0
+			currentControls.minPolarAngle = 0
+			currentControls.maxPolarAngle = 0
 
-		return () => {
-			currentControls.minPolarAngle = minPolarAngle
-			currentControls.maxPolarAngle = maxPolarAngle
+			return () => {
+				currentControls.minPolarAngle = minPolarAngle
+				currentControls.maxPolarAngle = maxPolarAngle
+			}
 		}
 	})
 

--- a/src/lib/components/Selection/Lasso.svelte
+++ b/src/lib/components/Selection/Lasso.svelte
@@ -244,16 +244,18 @@
 
 		const currentControls = controls.current
 
-		const { minPolarAngle, maxPolarAngle } = currentControls
+		if ('minPolarAngle' in currentControls) {
+			const { minPolarAngle, maxPolarAngle } = currentControls
 
-		// Locks the camera to top down while this component is mounted
-		currentControls.polarAngle = 0
-		currentControls.minPolarAngle = 0
-		currentControls.maxPolarAngle = 0
+			// Locks the camera to top down while this component is mounted
+			currentControls.polarAngle = 0
+			currentControls.minPolarAngle = 0
+			currentControls.maxPolarAngle = 0
 
-		return () => {
-			currentControls.minPolarAngle = minPolarAngle
-			currentControls.maxPolarAngle = maxPolarAngle
+			return () => {
+				currentControls.minPolarAngle = minPolarAngle
+				currentControls.maxPolarAngle = maxPolarAngle
+			}
 		}
 	})
 

--- a/src/lib/components/overlay/Details.svelte
+++ b/src/lib/components/overlay/Details.svelte
@@ -335,11 +335,13 @@
 						onclick={() => {
 							const padding = 0.4
 
-							if (!controls.current) return
+							const currentControls = controls.current
 
-							const { azimuthAngle, polarAngle } = controls.current
+							if (!currentControls || !('fitToBox' in currentControls)) return
 
-							controls.current.fitToBox(object3d, true, {
+							const { azimuthAngle, polarAngle } = currentControls
+
+							currentControls.fitToBox(object3d, true, {
 								paddingTop: padding,
 								paddingBottom: padding,
 								paddingLeft: padding,
@@ -347,8 +349,8 @@
 							})
 
 							// Preserve previous rotation
-							controls.current?.rotateAzimuthTo(azimuthAngle, true)
-							controls.current?.rotatePolarTo(polarAngle, true)
+							currentControls.rotateAzimuthTo(azimuthAngle, true)
+							currentControls.rotatePolarTo(polarAngle, true)
 						}}
 					>
 						<Icon name="image-filter-center-focus" />

--- a/src/lib/components/overlay/controls/Controls.svelte
+++ b/src/lib/components/overlay/controls/Controls.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import { PortalTarget } from '@threlte/extras'
+
+	import Button from '$lib/components/overlay/dashboard/Button.svelte'
+	import { useSettings } from '$lib/hooks/useSettings.svelte'
+
+	const settings = useSettings()
+
+	const isOrthographic = $derived(settings.current.cameraMode === 'orthographic')
+</script>
+
+<div class="absolute right-2 bottom-26 z-4 flex flex-col items-end gap-2">
+	<PortalTarget id="controls" />
+
+	<fieldset class="flex flex-col">
+		<Button
+			active
+			class="rounded-lg"
+			icon={isOrthographic ? 'grid-orthographic' : 'grid-perspective'}
+			description={isOrthographic ? 'Switch to perspective view' : 'Switch to orthographic view'}
+			hotkey="C"
+			tooltipLocation="left"
+			onclick={() => {
+				settings.current.cameraMode = isOrthographic ? 'perspective' : 'orthographic'
+			}}
+		/>
+	</fieldset>
+</div>

--- a/src/lib/components/overlay/controls/Controls.svelte
+++ b/src/lib/components/overlay/controls/Controls.svelte
@@ -2,9 +2,11 @@
 	import { PortalTarget } from '@threlte/extras'
 
 	import Button from '$lib/components/overlay/dashboard/Button.svelte'
+	import { useCameraControls } from '$lib/hooks/useControls.svelte'
 	import { useSettings } from '$lib/hooks/useSettings.svelte'
 
 	const settings = useSettings()
+	const cameraControls = useCameraControls()
 
 	const isOrthographic = $derived(settings.current.cameraMode === 'orthographic')
 </script>
@@ -15,7 +17,17 @@
 	<fieldset class="flex flex-col">
 		<Button
 			active
-			class="rounded-lg"
+			class="rounded-b-none"
+			icon="camera-outline"
+			description="Reset camera"
+			tooltipLocation="left"
+			onclick={() => {
+				cameraControls.setInitialPose()
+			}}
+		/>
+		<Button
+			active
+			class="-my-0.5 rounded-t-none"
 			icon={isOrthographic ? 'grid-orthographic' : 'grid-perspective'}
 			description={isOrthographic ? 'Switch to perspective view' : 'Switch to orthographic view'}
 			hotkey="C"

--- a/src/lib/components/overlay/dashboard/Button.svelte
+++ b/src/lib/components/overlay/dashboard/Button.svelte
@@ -10,7 +10,7 @@
 		description: string
 		hotkey?: string
 		class?: ClassValue | null | undefined
-		tooltipLocation?: 'bottom' | 'right'
+		tooltipLocation?: 'bottom' | 'right' | 'left' | 'top'
 		onclick?: MouseEventHandler<HTMLButtonElement> | null | undefined
 	}
 
@@ -33,13 +33,13 @@
 	<label
 		class={[
 			className,
-			'relative block border',
+			'relative block rounded-md border',
 			active ? 'border-gray-5 text-gray-8 z-4 bg-white' : 'bg-light border-medium text-disabled',
 		]}
 		aria-describedby={tooltipID}
 	>
 		<button
-			class="p-1.5"
+			class=" p-1.5"
 			role="radio"
 			aria-label={description}
 			aria-checked={active}

--- a/src/lib/components/overlay/dashboard/Dashboard.svelte
+++ b/src/lib/components/overlay/dashboard/Dashboard.svelte
@@ -14,33 +14,11 @@
 	class="absolute top-2 z-4 flex w-full items-center justify-center gap-2"
 	{...rest}
 >
-	<!-- camera view -->
-	<fieldset class="flex">
-		<Button
-			icon="grid-orthographic"
-			active={settings.current.cameraMode === 'orthographic'}
-			description="Orthographic view"
-			hotkey="C"
-			onclick={() => {
-				settings.current.cameraMode = 'orthographic'
-			}}
-		/>
-		<Button
-			icon="grid-perspective"
-			active={settings.current.cameraMode === 'perspective'}
-			description="Perspective view"
-			hotkey="C"
-			class="-ml-px"
-			onclick={() => {
-				settings.current.cameraMode = 'perspective'
-			}}
-		/>
-	</fieldset>
-
 	<!-- transform -->
 	<fieldset class="flex">
 		<Button
 			icon="mouse-pointer"
+			class="rounded-r-none"
 			active={settings.current.transformMode === 'none'}
 			description="No transform controls"
 			hotkey="0"
@@ -50,30 +28,30 @@
 		/>
 		<Button
 			icon="cursor-move"
+			class="-ml-px rounded-none"
 			active={settings.current.transformMode === 'translate'}
 			description="Translate"
 			hotkey="1"
-			class="-ml-px"
 			onclick={() => {
 				settings.current.transformMode = 'translate'
 			}}
 		/>
 		<Button
 			icon="sync"
+			class="-ml-px rounded-none"
 			active={settings.current.transformMode === 'rotate'}
 			description="Rotate"
 			hotkey="2"
-			class="-ml-px"
 			onclick={() => {
 				settings.current.transformMode = 'rotate'
 			}}
 		/>
 		<Button
 			icon="resize"
+			class="-ml-px rounded-l-none"
 			active={settings.current.transformMode === 'scale'}
 			description="Scale"
 			hotkey="3"
-			class="-ml-px"
 			onclick={() => {
 				settings.current.transformMode = 'scale'
 			}}
@@ -81,18 +59,17 @@
 	</fieldset>
 
 	<!-- snapping -->
-	{#if settings.current.transformMode !== 'none'}
-		<fieldset class="flex">
-			<Button
-				icon={settings.current.snapping ? 'magnet' : 'magnet-off'}
-				active={settings.current.snapping}
-				description="Snapping"
-				onclick={() => {
-					settings.current.snapping = !settings.current.snapping
-				}}
-			/>
-		</fieldset>
-	{/if}
+
+	<fieldset class="flex">
+		<Button
+			icon={settings.current.snapping ? 'magnet' : 'magnet-off'}
+			active={settings.current.snapping}
+			description="Snapping"
+			onclick={() => {
+				settings.current.snapping = !settings.current.snapping
+			}}
+		/>
+	</fieldset>
 
 	<PortalTarget id="dashboard" />
 

--- a/src/lib/hooks/useControls.svelte.ts
+++ b/src/lib/hooks/useControls.svelte.ts
@@ -1,5 +1,6 @@
 import type { CameraControlsRef } from '@threlte/extras'
 import type { Vector3Tuple } from 'three'
+import type { TrackballControls } from 'three/examples/jsm/Addons.js'
 
 import { getContext, setContext } from 'svelte'
 
@@ -12,31 +13,37 @@ export interface CameraPose {
 }
 
 interface CameraControlsContext {
-	current: CameraControlsRef | undefined
-	set(current: CameraControlsRef): void
+	current: CameraControlsRef | TrackballControls | undefined
+	set(current: CameraControlsRef | TrackballControls): void
 	setPose(pose: CameraPose, animate?: boolean): void
 	setInitialPose(): void
 	setZoom(zoom: number): void
 }
 
 export const provideCameraControls = (initialCameraPose: () => CameraPose | undefined) => {
-	let controls = $state.raw<CameraControlsRef>()
+	let controls = $state.raw<CameraControlsRef | TrackballControls>()
 
 	const setPose = (pose: CameraPose, animate = false) => {
 		const [x, y, z] = pose.position
 		const [lookAtX, lookAtY, lookAtZ] = pose.lookAt
 
-		controls?.setPosition(x, y, z, animate)
-		controls?.setLookAt(x, y, z, lookAtX, lookAtY, lookAtZ, animate)
+		if (controls && 'setPosition' in controls) {
+			controls.setPosition(x, y, z, animate)
+			controls.setLookAt(x, y, z, lookAtX, lookAtY, lookAtZ, animate)
+		}
 	}
 
 	const setZoom = (zoom: number) => {
-		controls?.zoomTo(zoom)
+		if (controls && 'zoomTo' in controls) controls?.zoomTo(zoom)
 	}
 
 	const setInitialPose = () => {
-		const pose = initialCameraPose()
-		setPose(pose ?? { position: [3, 3, 3], lookAt: [0, 0, 0] }, true)
+		if (controls && 'setPosition' in controls) {
+			const pose = initialCameraPose()
+			setPose(pose ?? { position: [3, 3, 3], lookAt: [0, 0, 0] }, true)
+		} else if (controls) {
+			controls.reset()
+		}
 	}
 
 	$effect(() => {
@@ -51,7 +58,7 @@ export const provideCameraControls = (initialCameraPose: () => CameraPose | unde
 		get current() {
 			return controls
 		},
-		set(current: CameraControlsRef) {
+		set(current) {
 			controls = current
 		},
 		setPose,

--- a/src/routes/lib/components/Machines.svelte
+++ b/src/routes/lib/components/Machines.svelte
@@ -76,7 +76,7 @@
 			{#if machineConnection.isAwaitingRetry}
 				<button
 					aria-label="Machine connection configs"
-					class="border-danger-medium bg-danger-light text-danger-dark flex items-center gap-2 border border-r-0 px-2.5 py-1.5 text-xs hover:bg-[#F8E1DF] focus:bg-[#F8E1DF]"
+					class="border-danger-medium bg-danger-light text-danger-dark flex items-center gap-2 rounded-l border border-r-0 px-2.5 py-1.5 text-xs hover:bg-[#F8E1DF] focus:bg-[#F8E1DF]"
 					onclick={() => {
 						isOpen = !isOpen
 					}}
@@ -85,10 +85,11 @@
 					<span class="truncate whitespace-nowrap"
 						>Retry in {machineConnection.secondsUntilRetry}s...</span
 					>
+					<Icon name="chevron-{isOpen ? 'up' : 'down'}" />
 				</button>
 				<button
 					aria-label="Reconnect now"
-					class="border-danger-medium bg-danger-light text-danger-dark flex items-center border px-2 py-1.5 text-xs hover:bg-[#F8E1DF] focus:bg-[#F8E1DF]"
+					class="border-danger-medium bg-danger-light text-danger-dark flex items-center rounded-r border px-2 py-1.5 text-xs hover:bg-[#F8E1DF] focus:bg-[#F8E1DF]"
 					onclick={machineConnection.retryNow}
 				>
 					<Icon name="refresh" />
@@ -97,7 +98,7 @@
 				<button
 					aria-label="Machine connection configs"
 					class={[
-						'flex items-center gap-2 border px-2.5 py-1.5 text-xs ',
+						'flex items-center gap-2 rounded border px-2.5 py-1.5 text-xs',
 						{
 							'border-gray-5 bg-white': !connected && !disconnected,
 							'border-success-medium bg-success-light text-success-dark hover:bg-[#D6F2D9] focus:bg-[#D6F2D9]':


### PR DESCRIPTION
### Overview

Moves camera control dashboard buttons to the bottom right and rounds out buttons to make button groups more obvious.

<img width="1042" height="650" alt="Screenshot 2026-05-21 at 09 43 00" src="https://github.com/user-attachments/assets/d9db8883-1ae7-4b07-9816-921a72880ea7" />
