### PR TITLE
Update gizmo-foundation-utils changeset

### DIFF
--- a/.changeset/gizmo-foundation-utils.md
+++ b/.changeset/gizmo-foundation-utils.md
@@ -2,4 +2,4 @@
 '@viamrobotics/motion-tools': patch
 ---
 
-Add `writeMatrix` and `CustomDetails` ECS traits, a `firstHitOnly` raycaster option, and a `'gizmo'` interaction mode
+Add `writeMatrix` and `CustomDetails` ECS traits, and a `'gizmo'` interaction mode


### PR DESCRIPTION
Removed the 'firstHitOnly' raycaster option from the changeset.