### PR TITLE
change confusing connection dialog names

### DIFF
--- a/e2e/fixtures/with-robot.ts
+++ b/e2e/fixtures/with-robot.ts
@@ -98,12 +98,12 @@ export const activateConnectionConfigByHost = async (page: Page, host: string) =
 
 	await expect(async () => {
 		const rows = page.locator('form').filter({
-			has: page.locator('input[placeholder="Host"]'),
+			has: page.locator('input[placeholder="Remote address"]'),
 		})
 		const count = await rows.count()
 		for (let index = 0; index < count; index += 1) {
 			const row = rows.nth(index)
-			if ((await row.locator('input[placeholder="Host"]').inputValue()) === host) {
+			if ((await row.locator('input[placeholder="Remote address"]').inputValue()) === host) {
 				const switchButton = row.getByRole('switch')
 				if ((await switchButton.getAttribute('aria-checked')) !== 'true') {
 					await switchButton.click()

--- a/src/routes/lib/components/Machines.svelte
+++ b/src/routes/lib/components/Machines.svelte
@@ -137,7 +137,7 @@
 
 					<Input
 						class="input w-full grow text-xs"
-						placeholder="Host"
+						placeholder="Remote address"
 						value={config.host}
 						on:change={(event) => {
 							connectionConfigs.current[index].host = (event.target as HTMLInputElement).value
@@ -217,12 +217,12 @@
 
 						<label
 							for="{config.host}-address"
-							class="text-xs">Signaling address</label
+							class="text-xs">Address of signaling server</label
 						>
 						<div class="col-span-2">
 							<Input
 								id="{config.host}-address"
-								placeholder="Signaling address"
+								placeholder="Address of signaling server"
 								value={config.signalingAddress}
 								on:change={(event) => {
 									connectionConfigs.current[index].signalingAddress = (


### PR DESCRIPTION
i always get confused what "host" mean and what "signaling address" means. there's already a "host" name on the app that means the literal name of the computer, but here "host" means "remote address", and "signaling address" sounds like it should mean the DNS address but it actually means the address of the signaling server

made copy changes to make this clearer

<img width="560" height="453" alt="image" src="https://github.com/user-attachments/assets/bac278bc-56a5-488b-99c9-2b82a2060c17" />

(what host means in regular app:)

<img width="493" height="268" alt="image" src="https://github.com/user-attachments/assets/188c53ca-daf6-450e-9c2e-96eef2564500" />
