### PR TITLE
Fix memory leak in WorldStateStoreService

### DIFF
--- a/.changeset/fix-world-state-stream-memory-leak.md
+++ b/.changeset/fix-world-state-stream-memory-leak.md
@@ -1,0 +1,5 @@
+---
+'@viamrobotics/motion-tools': patch
+---
+
+Fix unbounded memory growth from the world state transform stream

--- a/src/lib/hooks/useWorldState.svelte.ts
+++ b/src/lib/hooks/useWorldState.svelte.ts
@@ -278,15 +278,10 @@ const createWorldState = (client: { current: WorldStateStoreClient | undefined }
 	})
 
 	/**
-	 * Consumes the `streamTransformChanges` server stream directly rather than
-	 * through `createResourceStream`. The SDK's streaming helper is backed by
-	 * TanStack's `streamedQuery`, whose default reducer appends every event to
-	 * an array that is never trimmed (`addToEnd` with `max = 0`), so a
-	 * long-lived stream accumulates every transform change for the life of the
-	 * connection — an unbounded heap leak, compounded by re-scanning the whole
-	 * array on every emission. Transform changes are write-once into the ECS
-	 * world, so we drain each event into `pendingEvents` (cleared every flush)
-	 * and never retain history. Mirrors `useDrawService`'s stream consumption.
+	 * Consumes the `streamTransformChanges` server stream directly.
+	 * Transform changes are write-once into the ECS world, so we drain
+	 * each event into `pendingEvents` (cleared every flush) and never
+	 * retain history. Mirrors `useDrawService`'s stream consumption.
 	 */
 	const consumeChanges = async (signal: AbortSignal) => {
 		const activeClient = client.current

--- a/src/lib/hooks/useWorldState.svelte.ts
+++ b/src/lib/hooks/useWorldState.svelte.ts
@@ -11,7 +11,6 @@ import {
 import {
 	createResourceClient,
 	createResourceQuery,
-	createResourceStream,
 	useResourceNames,
 } from '@viamrobotics/svelte-sdk'
 import { Matrix4 } from 'three'
@@ -217,6 +216,7 @@ const createWorldState = (client: { current: WorldStateStoreClient | undefined }
 
 	let initialized = false
 	let flushScheduled = false
+	let rafId = 0
 	let pendingEvents: TransformEvent[] = []
 
 	const listUUIDs = createResourceQuery(client, 'listUUIDs')
@@ -230,10 +230,6 @@ const createWorldState = (client: { current: WorldStateStoreClient | undefined }
 			)
 		})
 	)
-
-	const changeStream = createResourceStream(client, 'streamTransformChanges', {
-		refetchMode: 'replace',
-	})
 
 	const applyEvents = (events: TransformEvent[]) => {
 		for (const event of events) {
@@ -255,12 +251,12 @@ const createWorldState = (client: { current: WorldStateStoreClient | undefined }
 		if (flushScheduled) return
 		flushScheduled = true
 
-		requestAnimationFrame(() => {
-			const toApply = pendingEvents
-
-			applyEvents(toApply)
+		rafId = requestAnimationFrame(() => {
+			rafId = 0
 			flushScheduled = false
+			const toApply = pendingEvents
 			pendingEvents = []
+			applyEvents(toApply)
 		})
 	}
 
@@ -281,65 +277,50 @@ const createWorldState = (client: { current: WorldStateStoreClient | undefined }
 		initialized = true
 	})
 
-	$effect(() => {
-		if (changeStream?.data === undefined) return
+	/**
+	 * Consumes the `streamTransformChanges` server stream directly rather than
+	 * through `createResourceStream`. The SDK's streaming helper is backed by
+	 * TanStack's `streamedQuery`, whose default reducer appends every event to
+	 * an array that is never trimmed (`addToEnd` with `max = 0`), so a
+	 * long-lived stream accumulates every transform change for the life of the
+	 * connection — an unbounded heap leak, compounded by re-scanning the whole
+	 * array on every emission. Transform changes are write-once into the ECS
+	 * world, so we drain each event into `pendingEvents` (cleared every flush)
+	 * and never retain history. Mirrors `useDrawService`'s stream consumption.
+	 */
+	const consumeChanges = async (signal: AbortSignal) => {
+		const activeClient = client.current
+		if (!activeClient) return
 
-		const eventsByUUID = new Map<string, TransformEvent>()
+		try {
+			for await (const event of activeClient.streamTransformChanges(undefined, { signal })) {
+				if (signal.aborted) break
+				if (!event.transform) continue
 
-		for (const event of changeStream.data) {
-			if (!event.transform) {
-				continue
+				pendingEvents.push(event as TransformEvent)
+				scheduleFlush()
 			}
-
-			const uuid = event.transform.uuidString
-			const existing = eventsByUUID.get(uuid)
-			if (!existing) {
-				eventsByUUID.set(uuid, event as TransformEvent)
-				continue
-			}
-
-			switch (event.changeType) {
-				case TransformChangeType.REMOVED: {
-					eventsByUUID.set(uuid, event as TransformEvent)
-					break
-				}
-
-				case TransformChangeType.ADDED: {
-					if (existing.changeType !== TransformChangeType.REMOVED) {
-						eventsByUUID.set(uuid, event as TransformEvent)
-					}
-					break
-				}
-
-				case TransformChangeType.UPDATED: {
-					// merge with existing updated event
-					if (existing.changeType === TransformChangeType.UPDATED) {
-						existing.updatedFields ??= { paths: [] }
-
-						const paths = event.updatedFields?.paths ?? []
-
-						for (const path of paths) {
-							if (existing.updatedFields.paths.includes(path)) {
-								continue
-							}
-
-							existing.updatedFields.paths.push(path)
-						}
-
-						existing.transform = event.transform
-					} else {
-						eventsByUUID.set(uuid, event as TransformEvent)
-					}
-					break
-				}
+		} catch (error) {
+			if (!signal.aborted) {
+				console.error('World state transform stream error:', error)
 			}
 		}
+	}
 
-		pendingEvents.push(...eventsByUUID.values())
-		scheduleFlush()
+	$effect(() => {
+		if (!client.current) return
+
+		const controller = new AbortController()
+		void consumeChanges(controller.signal)
+
+		return () => {
+			controller.abort()
+		}
 	})
 
 	return () => {
+		if (rafId) cancelAnimationFrame(rafId)
+		pendingEvents = []
 		chunkLoader.dispose()
 		for (const [, entity] of entities) {
 			if (world.has(entity)) {


### PR DESCRIPTION
### Overview

Fixes a memory leak that crashed long-running sessions when a world state store service was active. The world state hook consumed `streamTransformChanges` through the SDK's `createResourceStream`, which is backed by TanStack's `streamedQuery`. Its default reducer appends every streamed value to a cached array and never trims it (`addToEnd` with `max = 0`), and the configured `refetchMode: 'replace'` only applies on a refetch, not on the initial long-lived stream. As a result the hook retained every transform change event for the life of the connection and re-scanned the entire growing array on each emission, producing linear heap growth and O(n^2) main-thread work until the tab ran out of memory. Transform changes are write-once into the ECS world, so caching them provides no value. The hook now consumes the stream directly, drains each event into a per-frame buffer that is cleared after it is applied, and cancels the stream and any pending flush via an AbortController on teardown. This matches the existing pattern in `useDrawService` and bounds memory to the live entity set.