### PR TITLE
Update useFrames.svelte.ts

### DIFF
--- a/.changeset/free-rooms-serve.md
+++ b/.changeset/free-rooms-serve.md
@@ -1,0 +1,5 @@
+---
+'@viamrobotics/motion-tools': patch
+---
+
+useFrames condition to show LLM frame edit preview

--- a/src/lib/hooks/useFrames.svelte.ts
+++ b/src/lib/hooks/useFrames.svelte.ts
@@ -257,7 +257,7 @@ export const provideFrames = (partID: () => string) => {
 					// values would shift entities whose parents the user is portaling
 					// into — the gizmo's drag target moves underneath it. Once we're
 					// back in monitor mode, the next sync resumes the overwrite.
-					if (!isEditMode) {
+					if (!isEditMode || !editSession.current) {
 						const edited = existing.get(traits.EditedMatrix)
 						if (edited) {
 							poseToMatrix(pose, edited)


### PR DESCRIPTION
Reverted this condition line by mistake while pushing #740. Frame edits using the LLM editor now will show preview after edits are confirmed. 