### PR TITLE
Use wire-it for script management

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,13 +51,16 @@ jobs:
           go install connectrpc.com/connect/cmd/protoc-gen-connect-go@latest
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
+      - name: Set up wireit caching
+        uses: google/wireit@setup-github-actions-caching/v2
+
       - name: Install root deps
         run: pnpm install
 
+      # proto:gen-ts depends on proto:vendor, so vendoring runs (and is cached)
+      # automatically. deploy-docs restores that vendor cache for proto:gen-go.
       - name: Generate protobufs
-        run: |
-          make proto-vendor
-          make proto-gen-ts
+        run: pnpm proto:gen-ts
 
       - name: Build root app
         env:
@@ -111,13 +114,16 @@ jobs:
           go install github.com/princjef/gomarkdoc/cmd/gomarkdoc@latest
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
+      - name: Set up wireit caching
+        uses: google/wireit@setup-github-actions-caching/v2
+
       - name: Install root deps
         run: pnpm install
 
+      # proto:gen-go depends on proto:vendor; the vendor output is restored from
+      # the cache primed by build-app (this job `needs: build-app`).
       - name: Generate Go protobufs
-        run: |
-          make proto-vendor
-          make proto-gen-go
+        run: pnpm proto:gen-go
 
       - name: Install docs deps
         working-directory: docs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,9 @@ jobs:
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Set up wireit caching
+        uses: google/wireit@setup-github-actions-caching/v2
+
       - name: Install buf
         uses: bufbuild/buf-setup-action@v1
         with:
@@ -53,7 +56,7 @@ jobs:
       - name: Install and Build 🔧
         run: |
           pnpm i
-          make proto-gen-ts
+          pnpm proto:gen-ts
           pnpm build
 
       - name: Create Release Pull Request or Publish to npm

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -42,6 +42,10 @@ jobs:
           node-version: 24
           cache: 'pnpm'
 
+      - name: Set up wireit caching
+        if: github.event.action != 'closed'
+        uses: google/wireit@setup-github-actions-caching/v2
+
       - name: Setup Go
         if: github.event.action != 'closed'
         uses: actions/setup-go@v5
@@ -63,9 +67,9 @@ jobs:
       - name: Generate TypeScript protobufs
         if: github.event.action != 'closed'
         # Only TS protos are needed — the SvelteKit visualizer build doesn't
-        # touch the Go packages. docs.yml additionally runs proto-gen-go
+        # touch the Go packages. docs.yml additionally runs proto:gen-go
         # because gomarkdoc compiles the Go sources for the API reference.
-        run: make proto-gen-ts
+        run: pnpm proto:gen-ts
 
       - name: Build SvelteKit app
         if: github.event.action != 'closed'
@@ -73,7 +77,7 @@ jobs:
         # No trailing slash. The deploy step below mirrors this subpath.
         env:
           BASE_PATH: /visualization/pr-preview/pr-${{ github.event.number }}
-        run: pnpm vite build
+        run: pnpm vite-build
 
       - name: Deploy / cleanup preview
         uses: rossjrw/pr-preview-action@v1

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -38,6 +38,9 @@ jobs:
           node-version: 22
           cache: 'pnpm'
 
+      - name: Set up wireit caching
+        uses: google/wireit@setup-github-actions-caching/v2
+
       - name: Install dependencies
         run: pnpm install
 
@@ -60,23 +63,10 @@ jobs:
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
       - name: Generate protos
-        run: make proto
+        run: pnpm proto
 
       - name: Check proto formatting
-        run: make proto-format-check
-
-      - name: Upload TypeScript proto artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: protos-ts
-          path: |
-            src/lib/buf/
-
-      - name: Upload Go proto artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: protos-go
-          path: draw/v1/
+        run: pnpm proto:format-check
 
       - name: Commit generated Go protos
         if: steps.check-protos.outputs.protos == 'true'
@@ -109,6 +99,9 @@ jobs:
         with:
           node-version: 22
           cache: 'pnpm'
+
+      - name: Set up wireit caching
+        uses: google/wireit@setup-github-actions-caching/v2
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -147,15 +140,14 @@ jobs:
           node-version: 22
           cache: 'pnpm'
 
+      - name: Set up wireit caching
+        uses: google/wireit@setup-github-actions-caching/v2
+
       - name: Install dependencies
         run: pnpm install
 
-      - name: Download TypeScript proto artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: protos-ts
-          path: src/lib/buf/
-
+      # TS protos (src/lib/buf) are restored from the wireit cache primed by the
+      # proto-gen job (this job `needs: proto-gen`), so no buf/artifact needed.
       - name: Check
         run: pnpm check
 
@@ -181,20 +173,19 @@ jobs:
           node-version: 22
           cache: 'pnpm'
 
+      - name: Set up wireit caching
+        uses: google/wireit@setup-github-actions-caching/v2
+
       - name: Install dependencies
         run: pnpm install
 
       - name: Install Playwright browsers
         run: pnpm playwright install chromium --with-deps
 
-      - name: Download TypeScript proto artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: protos-ts
-          path: src/lib/buf/
-
+      # TS protos (src/lib/buf) are restored from the wireit cache primed by the
+      # proto-gen job (this job `needs: proto-gen`), so no buf/artifact needed.
       - name: Test
-        run: npx vitest run --coverage
+        run: pnpm test:coverage
 
       - name: Upload results to Codecov
         uses: codecov/codecov-action@v5
@@ -216,11 +207,7 @@ jobs:
           go-version: 1.23.11
           cache: true
 
-      - name: Download Go proto artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: protos-go
-          path: draw/v1/
-
+      # draw/v1 (generated Go protos) is committed, so it's already in the
+      # checkout — no artifact download needed.
       - name: Test Draw
         run: go test ./draw/... -count=1

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ static/test-fixtures
 # Temp files (disk-backed chunk storage)
 .tmp
 
+# wireit task cache/state
+.wireit
+
 # Output
 .output
 .vercel

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@
 
 ```
 make up            # build if needed, start server (ports 5173 + 3000)
-make proto         # vendor, lint, format, regenerate all protobuf
+pnpm proto         # vendor, lint, format, regenerate all protobuf
 pnpm check         # svelte-check + go vet
 pnpm lint          # prettier + eslint + golangci-lint
 pnpm lint:client   # golangci-lint for client/
@@ -32,7 +32,7 @@ pnpm test:e2e      # Playwright E2E
 ## Generated code — never hand-edit
 
 - Any files included in `.gitignore` should not be edited
-- Edit `.proto` files in `protos/`, then run `make proto`.
+- Edit `.proto` files in `protos/`, then run `pnpm proto`.
 
 ## Code organization
 

--- a/Makefile
+++ b/Makefile
@@ -1,122 +1,12 @@
-# Default target - show help when no target is specified
-.DEFAULT_GOAL := help
+# Local workflows:
+#
+#   make setup   one-time: install Node, pnpm, bun, Go, buf, deps, and protos
+#   make up      build (if needed) and start the dev server
 
-# Calculate hash of protobuf files that affect the build
-define calculate_proto_hash
-	(find protos -type f -exec cat {} \; 2>/dev/null) \
-	 | shasum -a 256 | cut -d' ' -f1
-endef
+.PHONY: setup up
 
-# Calculate hash of all app source files that affect the build
-define calculate_app_hash
-	(find src -type f -exec cat {} \; 2>/dev/null; \
-	 find static -type f -exec cat {} \; 2>/dev/null; \
-	 find protos -type f -exec cat {} \; 2>/dev/null; \
-	 cat package.json pnpm-lock.yaml svelte.config.js vite.config.ts tsconfig.json tailwind.config.ts 2>/dev/null) \
-	 | shasum -a 256 | cut -d' ' -f1
-endef
-
-# Calculate hash of all server source files that affect the build
-define calculate_server_hash
-	(find client -type f -exec cat {} \; 2>/dev/null; \
-	 find draw -type f -exec cat {} \; 2>/dev/null; \
-	 find protos -type f -exec cat {} \; 2>/dev/null; \
-	 find cmd/draw-server -type f -exec cat {} \; 2>/dev/null; \
-	 cat go.mod go.sum 2>/dev/null) \
-	 | shasum -a 256 | cut -d' ' -f1
-endef
-
-CURRENT_PROTO_HASH := $(shell $(call calculate_proto_hash))
-STORED_PROTO_HASH := $(shell cat .bin/.proto-build-stamp 2>/dev/null)
-
-CURRENT_APP_HASH := $(shell $(call calculate_app_hash))
-STORED_APP_HASH := $(shell cat .bin/.app-build-stamp 2>/dev/null)
-
-CURRENT_SERVER_HASH := $(shell $(call calculate_server_hash))
-STORED_SERVER_HASH := $(shell cat .bin/.server-build-stamp 2>/dev/null)
-
-.PHONY: help
-help:
-	@echo 'Motion Tools Development Setup'
-	@echo 'Usage: make [target]'
-	@echo ''
-	@echo 'Available targets:'
-	@echo '  setup          - Set up development environment (install pnpm, bun, dependencies)'
-	@echo '  up             - Build (if needed) and start the draw server'
-	@echo '  build          - Build the application for production'
-	@echo '  proto          - Generate protobuf code'
-	@echo '  help           - Show this help message'
-
-.PHONY: setup
 setup:
 	@./etc/setup.sh
 
-.PHONY: up-check
-up-check:
-	@if [ ! -d ".bin" ]; then \
-		mkdir -p .bin; \
-	fi
-	@if [ "$(CURRENT_PROTO_HASH)" != "$(STORED_PROTO_HASH)" ]; then \
-		$(MAKE) proto; \
-		echo "$(CURRENT_PROTO_HASH)" > .bin/.proto-build-stamp; \
-	fi
-	@if [ "$(CURRENT_APP_HASH)" != "$(STORED_APP_HASH)" ]; then \
-		pnpm build; \
-		echo "$(CURRENT_APP_HASH)" > .bin/.app-build-stamp; \
-	fi
-	@if [ "$(CURRENT_SERVER_HASH)" != "$(STORED_SERVER_HASH)" ]; then \
-		go build -o .bin/draw-server ./cmd/draw-server; \
-		echo "$(CURRENT_SERVER_HASH)" > .bin/.server-build-stamp; \
-	fi
-
-.PHONY: up
-up: up-check
-	@WS_PORT=3000 STATIC_PORT=5173 bun run server/server.ts --production > /dev/null 2>&1 &
-	@.bin/draw-server -port 3030
-
-.PHONY: build-clean
-build-clean:
-	@$(MAKE) proto-clean
-	@rm -rf build dist .build-stamp
-
-.PHONY: build
-build: build-clean
-	@$(MAKE) proto
-	@go build -o .bin/draw-server ./cmd/draw-server
-	@pnpm build
-
-.PHONY: proto-clean
-proto-clean:
-	@rm -rf draw/v1 src/lib/buf protos/vendor
-
-.PHONY: proto-gen-go
-proto-gen-go:
-	@PATH="$(shell go env GOPATH)/bin:$(shell pnpm bin):$$PATH" pnpm exec buf generate --template buf.gen.go.yaml
-
-.PHONY: proto-gen-ts
-proto-gen-ts:
-	@PATH="$(shell go env GOPATH)/bin:$(shell pnpm bin):$$PATH" pnpm exec buf generate --template buf.gen.typescript.yaml
-
-.PHONY: proto-vendor
-proto-vendor:
-	@pnpm exec buf export buf.build/viamrobotics/api --output protos/vendor
-
-.PHONY: proto-lint
-proto-lint:
-	@pnpm exec buf lint
-
-.PHONY: proto-format
-proto-format:
-	@pnpm exec buf format -w
-
-.PHONY: proto-format-check
-proto-format-check:
-	@pnpm exec buf format --diff --exit-code
-
-.PHONY: proto
-proto: proto-vendor 
-	@pnpm exec buf dep update
-	@$(MAKE) proto-lint
-	@$(MAKE) proto-format
-	@$(MAKE) proto-gen-go
-	@$(MAKE) proto-gen-ts
+up:
+	@pnpm up

--- a/docs/src/content/docs/guides/local-usage.mdx
+++ b/docs/src/content/docs/guides/local-usage.mdx
@@ -52,7 +52,7 @@ You need Go, Node.js 22+, pnpm, and `bun`. The setup script below installs the m
     4. Install dependencies and generate protobufs:
        ```bash
        pnpm install
-       make proto
+       pnpm proto
        ```
 
     </Steps>
@@ -190,7 +190,7 @@ make up STATIC_PORT=5180
 
 The WebSocket port (`:3000`) cannot be remapped yet; kill the conflicting process or wait for the issue above to be resolved.
 
-### `make proto` fails with "buf: command not found"
+### `pnpm proto` fails with "buf: command not found"
 
 `buf` isn't on your `PATH`. Re-run `make setup`, or install manually following [buf's instructions](https://buf.build/docs/installation), then retry.
 

--- a/etc/setup.sh
+++ b/etc/setup.sh
@@ -278,7 +278,7 @@ main() {
     install_node_dependencies
     
     # Step 9: Generate protobuf code
-    make proto
+    pnpm proto
 
     echo 
     echo -e "🎉 ${GREEN}Setup completed successfully!${NC}"
@@ -287,7 +287,7 @@ main() {
     print_shell_config
     
     echo -e "  1. Follow the shell configuration instructions above"
-    echo -e "  2. Run '${YELLOW}make up${NC}' to start the development server"
+    echo -e "  2. Run '${YELLOW}pnpm up${NC}' (or '${YELLOW}make up${NC}') to start the development server"
     echo -e "  3. Visit ${BLUE}http://localhost:5173/${NC} to view the application"
     echo
 }

--- a/package.json
+++ b/package.json
@@ -8,40 +8,447 @@
 		"dev": "concurrently \"pnpm dev:bun\" \"go run cmd/draw-server/main.go -port 3030\"",
 		"dev:bun": "tsx server/check-bun && bun run server/server.ts",
 		"dev:https": "vite dev -- --https",
-		"build": "vite build && npm run prepack",
-		"build:workers": "node scripts/build-workers.js",
-		"prepack": "svelte-kit sync && pnpm build:workers && svelte-package && publint",
+		"up": "wireit",
+		"build": "wireit",
+		"vite-build": "wireit",
+		"build:workers": "wireit",
+		"go-build": "wireit",
+		"package": "wireit",
+		"svelte-sync": "wireit",
+		"prepare": "pnpm svelte-sync && pnpm build:workers || echo ''",
+		"prepack": "wireit",
 		"preview": "vite preview",
-		"prepare": "svelte-kit sync && pnpm build:workers || echo ''",
-		"check": "svelte-kit sync && pnpm build:workers && svelte-check --tsconfig ./tsconfig.json && pnpm vet",
+		"check": "wireit",
 		"check:watch": "svelte-kit sync && pnpm build:workers && svelte-check --tsconfig ./tsconfig.json --watch",
-		"format": "prettier --write . && eslint . --fix",
-		"lint:draw": "golangci-lint run ./draw/...",
-		"lint:client": "golangci-lint run ./client/...",
-		"lint:prettier": "prettier --check .",
-		"lint:eslint": "eslint .",
-		"lint": "pnpm lint:prettier && pnpm lint:eslint && pnpm lint:draw",
+		"format": "prettier --write . && ./scripts/eslint-progress.sh . --fix",
+		"lint": "wireit",
+		"lint:prettier": "wireit",
+		"lint:eslint": "wireit",
+		"lint:draw": "wireit",
+		"lint:client": "wireit",
 		"knip": "npx knip --include files,exports,types",
+		"test": "wireit",
 		"test:unit": "vitest",
-		"test:client": "go test ./client/... -count=1",
-		"test:draw": "go test ./draw/... -count=1",
-		"test": "pnpm test:unit -- --run",
-		"test:coverage": "npx vitest run --coverage",
+		"test:unit-run": "wireit",
+		"test:coverage": "wireit",
+		"test:client": "wireit",
+		"test:draw": "wireit",
 		"test:e2e": "./e2e/setup.sh && playwright test",
 		"test:e2e-ui": "./e2e/setup.sh && playwright test --ui",
-		"vet:draw": "go vet ./draw/...",
-		"vet:client": "go vet ./client/...",
-		"vet": "pnpm vet:draw && pnpm vet:client",
-		"model-pipeline:run": "node scripts/model-pipeline.js",
+		"vet": "wireit",
+		"vet:draw": "wireit",
+		"vet:client": "wireit",
+		"proto": "wireit",
+		"proto:vendor": "wireit",
+		"proto:dep-update": "buf dep update",
+		"proto:gen-go": "wireit",
+		"proto:gen-ts": "wireit",
+		"proto:lint": "wireit",
+		"proto:format": "buf format -w",
+		"proto:format-check": "wireit",
+		"proto:clean": "rm -rf src/lib/buf protos/vendor",
+		"model-pipeline:run": "wireit",
 		"release": "changeset publish",
 		"docs:dev": "pnpm --dir docs dev",
 		"docs:build": "pnpm --dir docs build",
 		"docs:preview": "pnpm --dir docs preview"
 	},
+	"wireit": {
+		"up": {
+			"command": "WS_PORT=3000 STATIC_PORT=5173 bun run server/server.ts --production > /dev/null 2>&1 & .bin/draw-server -port 3030",
+			"dependencies": [
+				"vite-build",
+				"go-build"
+			]
+		},
+		"build": {
+			"dependencies": [
+				"vite-build",
+				"package"
+			]
+		},
+		"vite-build": {
+			"command": "vite build",
+			"files": [
+				"src/**",
+				"static/**",
+				"vite.config.ts",
+				"svelte.config.js",
+				"tsconfig.json",
+				"tailwind.config.ts",
+				"package.json"
+			],
+			"output": [
+				"build/**",
+				".svelte-kit/output/**"
+			],
+			"dependencies": [
+				"proto:gen-ts",
+				"svelte-sync",
+				"build:workers"
+			],
+			"packageLocks": [
+				"pnpm-lock.yaml"
+			],
+			"env": {
+				"BASE_PATH": {
+					"external": true
+				},
+				"WS_PORT": {
+					"external": true
+				},
+				"STATIC_PORT": {
+					"external": true
+				}
+			}
+		},
+		"build:workers": {
+			"command": "node scripts/build-workers.js",
+			"files": [
+				"scripts/build-workers.js",
+				"src/lib/loaders/pcd/worker.ts"
+			],
+			"output": [
+				"src/lib/loaders/pcd/worker.inline.ts"
+			],
+			"packageLocks": [
+				"pnpm-lock.yaml"
+			]
+		},
+		"go-build": {
+			"command": "go build -o .bin/draw-server ./cmd/draw-server",
+			"files": [
+				"cmd/draw-server/**",
+				"client/**",
+				"draw/**",
+				"go.mod",
+				"go.sum"
+			],
+			"output": [
+				".bin/draw-server"
+			]
+		},
+		"package": {
+			"command": "svelte-package && publint",
+			"files": [
+				"src/lib/**",
+				"svelte.config.js",
+				"tsconfig.json",
+				"package.json"
+			],
+			"output": [
+				"dist/**"
+			],
+			"dependencies": [
+				"proto:gen-ts",
+				"svelte-sync",
+				"build:workers"
+			],
+			"packageLocks": [
+				"pnpm-lock.yaml"
+			]
+		},
+		"svelte-sync": {
+			"command": "svelte-kit sync",
+			"files": [
+				"svelte.config.js",
+				"src/**",
+				"tsconfig.json"
+			],
+			"output": [
+				".svelte-kit/generated/**",
+				".svelte-kit/types/**",
+				".svelte-kit/ambient.d.ts",
+				".svelte-kit/non-ambient.d.ts",
+				".svelte-kit/env.d.ts",
+				".svelte-kit/tsconfig.json"
+			],
+			"packageLocks": [
+				"pnpm-lock.yaml"
+			]
+		},
+		"prepack": {
+			"dependencies": [
+				"package"
+			]
+		},
+		"check": {
+			"command": "svelte-check --tsconfig ./tsconfig.json",
+			"files": [
+				"src/**",
+				"tsconfig.json",
+				"svelte.config.js",
+				"package.json"
+			],
+			"output": [],
+			"dependencies": [
+				"proto:gen-ts",
+				"svelte-sync",
+				"build:workers",
+				"vet"
+			],
+			"packageLocks": [
+				"pnpm-lock.yaml"
+			]
+		},
+		"lint": {
+			"dependencies": [
+				"lint:prettier",
+				"lint:eslint",
+				"lint:draw"
+			]
+		},
+		"lint:prettier": {
+			"command": "prettier --check .",
+			"files": [
+				"**",
+				"!.bin/**",
+				"!build/**",
+				"!dist/**",
+				"!.svelte-kit/**",
+				"!.astro/**",
+				"!.output/**",
+				"!coverage/**",
+				"!test-results/**",
+				"!.tmp/**",
+				"!src/lib/buf/**",
+				"!protos/vendor/**",
+				"!draw/v1/**",
+				"!**/*.inline.ts",
+				"!**/__snapshots__/**",
+				"!**/*-snapshots/**",
+				"!static/test-fixtures/**",
+				"!static/Big_Buck_Bunny_4K.webm",
+				"!e2e/.bin/**",
+				"!docs/.astro/**",
+				"!docs/dist/**",
+				"!docs/node_modules/**",
+				"!docs/public/playground/**",
+				"!docs/src/content/docs/api/**",
+				"!**/*.tgz"
+			],
+			"output": [],
+			"packageLocks": [
+				"pnpm-lock.yaml"
+			]
+		},
+		"lint:eslint": {
+			"command": "TSESTREE_SINGLE_RUN=true eslint .",
+			"files": [
+				"**",
+				"!.bin/**",
+				"!build/**",
+				"!dist/**",
+				"!.svelte-kit/**",
+				"!.astro/**",
+				"!.output/**",
+				"!coverage/**",
+				"!test-results/**",
+				"!.tmp/**",
+				"!src/lib/buf/**",
+				"!protos/vendor/**",
+				"!draw/v1/**",
+				"!**/*.inline.ts",
+				"!**/__snapshots__/**",
+				"!**/*-snapshots/**",
+				"!static/test-fixtures/**",
+				"!static/Big_Buck_Bunny_4K.webm",
+				"!e2e/.bin/**",
+				"!docs/.astro/**",
+				"!docs/dist/**",
+				"!docs/node_modules/**",
+				"!docs/public/playground/**",
+				"!docs/src/content/docs/api/**",
+				"!**/*.tgz"
+			],
+			"output": [],
+			"packageLocks": [
+				"pnpm-lock.yaml"
+			]
+		},
+		"lint:draw": {
+			"command": "golangci-lint run ./draw/...",
+			"files": [
+				"draw/**",
+				"go.mod",
+				"go.sum",
+				".golangci.yml"
+			],
+			"output": []
+		},
+		"lint:client": {
+			"command": "golangci-lint run ./client/...",
+			"files": [
+				"client/**",
+				"go.mod",
+				"go.sum",
+				".golangci.yml"
+			],
+			"output": []
+		},
+		"vet": {
+			"dependencies": [
+				"vet:draw",
+				"vet:client"
+			]
+		},
+		"vet:draw": {
+			"command": "go vet ./draw/...",
+			"files": [
+				"draw/**",
+				"go.mod",
+				"go.sum"
+			],
+			"output": []
+		},
+		"vet:client": {
+			"command": "go vet ./client/...",
+			"files": [
+				"client/**",
+				"go.mod",
+				"go.sum"
+			],
+			"output": []
+		},
+		"test": {
+			"dependencies": [
+				"test:unit-run"
+			]
+		},
+		"test:unit-run": {
+			"command": "vitest --run",
+			"files": [
+				"src/**",
+				"vite.config.ts",
+				"vitest-setup-client.ts",
+				"tsconfig.json"
+			],
+			"output": [],
+			"dependencies": [
+				"proto:gen-ts"
+			],
+			"packageLocks": [
+				"pnpm-lock.yaml"
+			]
+		},
+		"test:coverage": {
+			"command": "vitest run --coverage",
+			"files": [
+				"src/**",
+				"vite.config.ts",
+				"vitest-setup-client.ts",
+				"tsconfig.json"
+			],
+			"output": [
+				"coverage/**"
+			],
+			"dependencies": [
+				"proto:gen-ts"
+			],
+			"packageLocks": [
+				"pnpm-lock.yaml"
+			]
+		},
+		"test:client": {
+			"command": "go test ./client/... -count=1",
+			"files": [
+				"client/**",
+				"go.mod",
+				"go.sum"
+			],
+			"output": []
+		},
+		"test:draw": {
+			"command": "go test ./draw/... -count=1",
+			"files": [
+				"draw/**",
+				"go.mod",
+				"go.sum"
+			],
+			"output": []
+		},
+		"proto": {
+			"command": "pnpm proto:dep-update && pnpm proto:format && pnpm proto:lint && pnpm proto:gen-go && pnpm proto:gen-ts",
+			"dependencies": [
+				"proto:vendor"
+			]
+		},
+		"proto:vendor": {
+			"command": "buf export buf.build/viamrobotics/api --output protos/vendor",
+			"files": [
+				"buf.yaml",
+				"buf.lock"
+			],
+			"output": [
+				"protos/vendor/**"
+			]
+		},
+		"proto:gen-go": {
+			"command": "PATH=\"$(go env GOPATH)/bin:$PATH\" buf generate --template buf.gen.go.yaml",
+			"files": [
+				"protos/draw/**",
+				"protos/vendor/**",
+				"buf.gen.go.yaml",
+				"buf.yaml",
+				"buf.lock"
+			],
+			"output": [],
+			"dependencies": [
+				"proto:vendor"
+			]
+		},
+		"proto:gen-ts": {
+			"command": "buf generate --template buf.gen.typescript.yaml",
+			"files": [
+				"protos/draw/**",
+				"protos/vendor/**",
+				"buf.gen.typescript.yaml",
+				"buf.yaml",
+				"buf.lock"
+			],
+			"output": [
+				"src/lib/buf/**"
+			],
+			"clean": true,
+			"dependencies": [
+				"proto:vendor"
+			]
+		},
+		"proto:lint": {
+			"command": "buf lint",
+			"files": [
+				"protos/draw/**",
+				"buf.yaml"
+			],
+			"output": []
+		},
+		"proto:format-check": {
+			"command": "buf format --diff --exit-code",
+			"files": [
+				"protos/draw/**"
+			],
+			"output": []
+		},
+		"model-pipeline:run": {
+			"command": "node scripts/model-pipeline.js",
+			"files": [
+				"scripts/model-pipeline.js",
+				"static/models/*.glb",
+				"static/models/*.gltf"
+			],
+			"output": [
+				"src/lib/components/models/*.svelte"
+			],
+			"packageLocks": [
+				"pnpm-lock.yaml"
+			]
+		}
+	},
 	"devDependencies": {
 		"@ag-grid-community/client-side-row-model": "32.3.9",
 		"@ag-grid-community/core": "32.3.9",
 		"@ag-grid-community/styles": "32.3.9",
+		"@bufbuild/buf": "1.69.0",
 		"@changesets/cli": "2.29.6",
 		"@connectrpc/connect": "1.7.0",
 		"@connectrpc/connect-web": "1.7.0",
@@ -122,6 +529,7 @@
 		"vite-plugin-glsl": "^1.5.5",
 		"vite-plugin-mkcert": "1.17.9",
 		"vitest": "4.1.9",
+		"wireit": "0.14.13",
 		"zod": "^4.4.3"
 	},
 	"peerDependencies": {
@@ -172,6 +580,7 @@
 	},
 	"pnpm": {
 		"onlyBuiltDependencies": [
+			"@bufbuild/buf",
 			"@sentry/cli",
 			"@tailwindcss/oxide",
 			"esbuild"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ importers:
       '@ag-grid-community/styles':
         specifier: 32.3.9
         version: 32.3.9
+      '@bufbuild/buf':
+        specifier: 1.69.0
+        version: 1.69.0
       '@changesets/cli':
         specifier: 2.29.6
         version: 2.29.6(@types/node@25.6.0)
@@ -289,6 +292,9 @@ importers:
       vitest:
         specifier: 4.1.9
         version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@26.1.0)(vite@8.1.0(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.20.5)(yaml@2.8.1))
+      wireit:
+        specifier: 0.14.13
+        version: 0.14.13
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -418,6 +424,53 @@ packages:
 
   '@blazediff/core@1.9.1':
     resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
+
+  '@bufbuild/buf-darwin-arm64@1.69.0':
+    resolution: {integrity: sha512-q7086l1PRS0fUn/IYef7WUAq5PEPIxCh3AVZZdObdOAA9C77ES7CYBSTWH3oEJHVElv1KPVVqvGmOC+G78HuXg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@bufbuild/buf-darwin-x64@1.69.0':
+    resolution: {integrity: sha512-ihM+lr0tahgLVbQvp5jhYS6T1cpydEX3TbJvAfePLJBCTrsXFMwKt1WIDjpSHIPHQABcqL9BuNnbs8r1+7E1MA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@bufbuild/buf-linux-aarch64@1.69.0':
+    resolution: {integrity: sha512-4twJF1ehcPRBvgA2g2yIG/3ViZ3SrElqCqGjXHp+U4RfjHV249j8kzVj08mvI1t0kv8Rbm8JECYqkxcYnKyuRA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@bufbuild/buf-linux-armv7@1.69.0':
+    resolution: {integrity: sha512-zfbYrfPjOBp1Dxj+9avW05NWzGwLUTInfslhgWVbq61DYLegX6UW12hVk5xS/C5D0IlfIDfJUXEeTsHImigQTQ==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@bufbuild/buf-linux-x64@1.69.0':
+    resolution: {integrity: sha512-mt/hJesHK62TlsSJPwBpRIC/OzWTlgaRmyjC8QF+T6+IbFwiwz1E3ZBCfNECEa2HW4ma8HbugpJyCBbUSA+z/Q==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@bufbuild/buf-win32-arm64@1.69.0':
+    resolution: {integrity: sha512-IlMSIdCWvllwenbLlrWEH2YHQwCqmONKZYv4MXj56v6TvCWCTbYlaF5ZFP+xFAHToHp1OrFc+rwUqCt7ElBbHg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@bufbuild/buf-win32-x64@1.69.0':
+    resolution: {integrity: sha512-wpKZLXUF/w85g4ZL9XqQqm33cfw2NRjiidSX5EVFMx4rDp7cnAUv3+PTwZvEPriqJEihnOJ5JCozsxjiWqSX7Q==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@bufbuild/buf@1.69.0':
+    resolution: {integrity: sha512-hWk7cW6Z/7g6jpybePaf15QUUFd2+s4lJCeaAkBeo3tWPGoSgNJaJdMqIUy2y99uYy4yMjq9GYmjc5dSrfIn5A==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   '@bufbuild/protobuf@1.10.1':
     resolution: {integrity: sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==}
@@ -2317,6 +2370,10 @@ packages:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
 
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
+
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
@@ -3074,6 +3131,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
@@ -3649,6 +3709,9 @@ packages:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
 
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+
   proxy-compare@3.0.1:
     resolution: {integrity: sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==}
 
@@ -3733,6 +3796,10 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -3804,6 +3871,9 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
@@ -4272,6 +4342,11 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wireit@0.14.13:
+    resolution: {integrity: sha512-Fo/VlEZKY4j53DQoW7Z/fWFrNGbnrfphgVDJdFoas5rVWUA9Z14/3AixEZcEfAuywympLCq49sTXVcD+sNtIxg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
@@ -4494,6 +4569,37 @@ snapshots:
   '@bcoe/v8-coverage@1.0.2': {}
 
   '@blazediff/core@1.9.1': {}
+
+  '@bufbuild/buf-darwin-arm64@1.69.0':
+    optional: true
+
+  '@bufbuild/buf-darwin-x64@1.69.0':
+    optional: true
+
+  '@bufbuild/buf-linux-aarch64@1.69.0':
+    optional: true
+
+  '@bufbuild/buf-linux-armv7@1.69.0':
+    optional: true
+
+  '@bufbuild/buf-linux-x64@1.69.0':
+    optional: true
+
+  '@bufbuild/buf-win32-arm64@1.69.0':
+    optional: true
+
+  '@bufbuild/buf-win32-x64@1.69.0':
+    optional: true
+
+  '@bufbuild/buf@1.69.0':
+    optionalDependencies:
+      '@bufbuild/buf-darwin-arm64': 1.69.0
+      '@bufbuild/buf-darwin-x64': 1.69.0
+      '@bufbuild/buf-linux-aarch64': 1.69.0
+      '@bufbuild/buf-linux-armv7': 1.69.0
+      '@bufbuild/buf-linux-x64': 1.69.0
+      '@bufbuild/buf-win32-arm64': 1.69.0
+      '@bufbuild/buf-win32-x64': 1.69.0
 
   '@bufbuild/protobuf@1.10.1': {}
 
@@ -6652,6 +6758,10 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
+
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
@@ -7451,6 +7561,8 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsonc-parser@3.3.1: {}
+
   jsonfile@4.0.0:
     optionalDependencies:
       graceful-fs: 4.2.11
@@ -7841,6 +7953,12 @@ snapshots:
 
   progress@2.0.3: {}
 
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
+
   proxy-compare@3.0.1: {}
 
   proxy-from-env@1.1.0: {}
@@ -7918,6 +8036,8 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  retry@0.12.0: {}
+
   reusify@1.1.0: {}
 
   rolldown@1.1.3:
@@ -7992,6 +8112,8 @@ snapshots:
   shimmer@1.2.1: {}
 
   siginfo@2.0.0: {}
+
+  signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
 
@@ -8424,6 +8546,14 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wireit@0.14.13:
+    dependencies:
+      brace-expansion: 5.0.6
+      chokidar: 3.6.0
+      fast-glob: 3.3.3
+      jsonc-parser: 3.3.1
+      proper-lockfile: 4.1.2
 
   word-wrap@1.2.5: {}
 

--- a/protos/README.md
+++ b/protos/README.md
@@ -25,19 +25,22 @@ The protos use separate buf templates for different languages:
 
 ### Generate Code
 
-**Generate both Go and TypeScript:**
+**Generate both Go and TypeScript** (vendor, lint, format, then generate):
 
 ```bash
-make proto-gen
+pnpm proto
 ```
 
 ### Other Commands
 
 ```bash
-make proto-lint    # Lint proto files
-make proto-format  # Format proto files
-make proto-clean   # Remove generated code
-make proto-vendor  # Vendor dependencies
+pnpm proto:gen-go       # Generate Go only
+pnpm proto:gen-ts       # Generate TypeScript only
+pnpm proto:lint         # Lint proto files
+pnpm proto:format       # Format proto files
+pnpm proto:format-check # Check proto formatting (no writes)
+pnpm proto:clean        # Remove generated TypeScript + vendored deps
+pnpm proto:vendor       # Vendor dependencies
 ```
 
 ## Dependencies
@@ -56,7 +59,7 @@ To ensure consistent builds and enable offline development, external protobuf de
 **Update vendored dependencies:**
 
 ```bash
-make proto-vendor
+pnpm proto:vendor
 ```
 
 This command:
@@ -71,6 +74,6 @@ This command:
 - When vendored files are missing or corrupted
 - When setting up a new development environment
 
-> **Note**: The `proto-gen` target automatically runs `proto-vendor` to ensure dependencies are up-to-date before code generation.
+> **Note**: `proto:gen-go` and `proto:gen-ts` depend on `proto:vendor` (via wireit), so vendoring runs automatically before code generation when needed.
 
 The buf configuration (`buf.yaml`) handles path resolution for both local and vendored protos.

--- a/scripts/eslint-progress.sh
+++ b/scripts/eslint-progress.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Run ESLint with a live elapsed-time indicator. The type-aware pass
+# (projectService) is silent for ~30-60s, which looks like a hang in plain
+# scripts such as `pnpm format`.
+#
+# TSESTREE_SINGLE_RUN forces single-run mode so the TS program tears down and
+# the process exits promptly.
+set -uo pipefail
+
+# Resolve eslint from the repo's node_modules whether invoked via pnpm or directly.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export PATH="$ROOT/node_modules/.bin:$PATH"
+export TSESTREE_SINGLE_RUN=true
+
+if [ ! -t 1 ]; then
+	exec eslint "$@"
+fi
+
+out="$(mktemp)"
+trap 'rm -f "$out"' EXIT
+
+eslint "$@" --color >"$out" 2>&1 &
+pid=$!
+
+start=$SECONDS
+while kill -0 "$pid" 2>/dev/null; do
+	printf '\r\033[36m⏳ ESLint (no output until done)…\033[0m %ds ' "$((SECONDS - start))"
+	sleep 1
+done
+printf '\r\033[2K'
+
+wait "$pid"
+code=$?
+cat "$out"
+exit "$code"


### PR DESCRIPTION
Migrated all of our scripts/processes to use [wireit](https://github.com/google/wireit) to manage orchestration, dependencies, and caching. This should speed up local builds and CI by avoiding unnecessary rebuilds and by parallelizing tasks. 

I left the `Makefile` around to keep `make setup` and `make up` available for folks, but they mostly point to pnpm scripts now. The `setup` target still uses a shell script to make sure node and pnpm are installed first.

I also added a simple shell script to render a timer when running eslint, so it doesn't look like scripts like `pnpm format` are hanging.