### PR TITLE
scene builder UI improvements

### DIFF
--- a/.changeset/hungry-breads-end.md
+++ b/.changeset/hungry-breads-end.md
@@ -1,0 +1,5 @@
+---
+'@viamrobotics/motion-tools': patch
+---
+
+UI/UX LLM scene builder improvements

--- a/src/lib/components/overlay/FloatingPanel.svelte
+++ b/src/lib/components/overlay/FloatingPanel.svelte
@@ -10,6 +10,7 @@
 	interface Props {
 		title?: string
 		defaultSize?: { width: number; height: number }
+		minSize?: { width: number; height: number }
 		defaultPosition?: { x: number; y: number }
 		exitable?: boolean
 		resizable?: boolean

--- a/src/lib/plugins/LLMSceneBuilder/DiffHeaderLabel.svelte
+++ b/src/lib/plugins/LLMSceneBuilder/DiffHeaderLabel.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	import type { ClassValue } from 'svelte/elements'
+
+	import { TooltipContainer, TooltipTarget, TooltipText } from '@viamrobotics/prime-core'
+	import { useResizeObserver } from 'runed'
+
+	interface Props {
+		text: string
+		tooltipText?: string
+		class?: ClassValue
+		containerClass?: ClassValue
+	}
+
+	let { text, tooltipText, class: textClass = '', containerClass = '' }: Props = $props()
+
+	let showTooltip = $state(false)
+	let element = $state<HTMLElement | null>(null)
+
+	useResizeObserver(
+		() => element,
+		() => {
+			if (!element) {
+				return
+			}
+			showTooltip = text.length > 0 && element.offsetWidth < element.scrollWidth
+		}
+	)
+</script>
+
+<div class={['min-w-0', containerClass]}>
+	<TooltipContainer hoverDelayMS={250}>
+		<TooltipTarget>
+			<span
+				bind:this={element}
+				class={['block w-full truncate', textClass]}
+				aria-label={tooltipText ?? text}
+			>
+				{text}
+			</span>
+		</TooltipTarget>
+
+		{#if showTooltip}
+			<TooltipText location="top-start">
+				{tooltipText ?? text}
+			</TooltipText>
+		{/if}
+	</TooltipContainer>
+</div>

--- a/src/lib/plugins/LLMSceneBuilder/SceneBuilder.svelte
+++ b/src/lib/plugins/LLMSceneBuilder/SceneBuilder.svelte
@@ -5,6 +5,7 @@
 	import DashboardButton from '$lib/components/overlay/dashboard/Button.svelte'
 	import FloatingPanel from '$lib/components/overlay/FloatingPanel.svelte'
 
+	import DiffHeaderLabel from './DiffHeaderLabel.svelte'
 	import { useSceneBuilder } from './useSceneBuilder.svelte'
 
 	const sceneBuilder = useSceneBuilder()
@@ -31,13 +32,14 @@
 		bind:isOpen
 		title="LLM Scene Builder"
 		defaultSize={{ width: 480, height: 420 }}
+		minSize={{ width: 360, height: 240 }}
 		resizable
 	>
-		<div class="flex h-full flex-col gap-3 p-3 text-xs">
+		<div class="flex h-full min-h-0 min-w-0 flex-col gap-3 p-3 text-xs">
 			<!-- prompt input -->
-			<div class="flex gap-2">
+			<div class="flex min-w-0 gap-2">
 				<textarea
-					class="flex-1 resize-none rounded border border-gray-300 p-2 text-xs focus:ring-1 focus:ring-gray-400 focus:outline-none disabled:bg-gray-50 disabled:text-gray-400"
+					class="min-w-0 flex-1 resize-none rounded border border-gray-300 p-2 text-xs focus:ring-1 focus:ring-gray-400 focus:outline-none disabled:bg-gray-50 disabled:text-gray-400"
 					placeholder="Describe a frame change — translation, rotation, or parent. e.g. 'Move arm 200mm forward and rotate 90° left'"
 					rows={3}
 					disabled={sceneBuilder.uiState === 'loading' || sceneBuilder.uiState === 'diff'}
@@ -52,7 +54,7 @@
 					}}
 				></textarea>
 				<button
-					class="self-end rounded bg-gray-800 px-3 py-1.5 text-xs text-white hover:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-40"
+					class="shrink-0 self-end rounded bg-gray-800 px-3 py-1.5 text-xs text-nowrap text-white hover:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-40"
 					disabled={!canSubmit}
 					onclick={() => {
 						sceneBuilder.submit(prompt)
@@ -70,66 +72,93 @@
 
 			<!-- diff ready -->
 			{#if sceneBuilder.uiState === 'diff'}
-				{#if sceneBuilder.diffGroups.length > 0}
-					<div class="flex flex-col gap-2 overflow-auto">
-						{#each sceneBuilder.diffGroups as group (group.componentName)}
-							<div class="rounded border border-gray-200">
-								<div
-									class="flex items-baseline gap-2 border-b border-gray-200 bg-gray-50 px-2 py-1"
-								>
-									<span class="font-mono font-medium">{group.componentName}</span>
-									{#if group.explanation}
-										<span class="text-gray-5 truncate italic">{group.explanation}</span>
-									{/if}
-								</div>
-								<table class="w-full text-left">
-									<thead class="sr-only">
-										<tr>
-											<th>Field</th>
-											<th>Before</th>
-											<th>After</th>
-										</tr>
-									</thead>
-									<tbody>
-										{#each group.changes as change (change.field)}
-											<tr class="border-t border-gray-100 first:border-t-0">
-												<td class="px-2 py-1 font-mono">{change.field}</td>
-												<td class="text-red-6 px-2 py-1 font-mono">{change.oldValue}</td>
-												<td class="text-green-6 px-2 py-1 font-mono">{change.newValue}</td>
-											</tr>
-										{/each}
-									</tbody>
-								</table>
+				<div class="flex min-h-0 flex-1 flex-col gap-3">
+					{#if sceneBuilder.diffGroups.length > 0}
+						<div class="min-h-0 flex-1 overflow-auto">
+							<div class="flex flex-col gap-2">
+								{#each sceneBuilder.diffGroups as group (group.componentName)}
+									<div class="flex min-w-0 flex-col gap-1">
+										<div class="flex min-w-0 items-center gap-1.5 px-2 py-1">
+											<DiffHeaderLabel
+												text={group.componentName}
+												containerClass={group.explanation
+													? 'max-w-[45%] shrink-0'
+													: 'min-w-0 flex-1'}
+												class="font-mono font-medium"
+											/>
+											{#if group.explanation}
+												<span
+													class="text-gray-5 shrink-0"
+													aria-hidden="true">·</span
+												>
+												<DiffHeaderLabel
+													text={group.explanation}
+													containerClass="min-w-0 flex-1"
+													class="text-gray-5 italic"
+												/>
+											{/if}
+										</div>
+										<div class="rounded border border-gray-200">
+											<table class="w-full text-left">
+												<thead>
+													<tr class="border-b border-gray-200 bg-gray-50">
+														<th class="text-subtle-1 px-2 py-1 font-normal">Field</th>
+														<th class="text-subtle-1 px-2 py-1 font-normal">Old</th>
+														<th class="text-subtle-1 px-2 py-1 font-normal">New</th>
+													</tr>
+												</thead>
+												<tbody>
+													{#each group.changes as change (change.field)}
+														<tr class="border-t border-gray-100 first:border-t-0">
+															<td class="px-2 py-1 font-mono">{change.field}</td>
+															<td class="bg-danger-light text-danger-dark px-2 py-1 font-mono"
+																>{change.oldValue}</td
+															>
+															<td class="bg-success-light text-success-dark px-2 py-1 font-mono"
+																>{change.newValue}</td
+															>
+														</tr>
+													{/each}
+												</tbody>
+											</table>
+										</div>
+									</div>
+								{/each}
 							</div>
-						{/each}
-					</div>
-				{:else}
-					<p class="text-gray-5 text-center">No frame changes proposed.</p>
-				{/if}
+						</div>
+					{:else}
+						<p class="text-gray-5 text-center">No frame changes proposed.</p>
+					{/if}
 
-				{#if sceneBuilder.updateErrors.length > 0}
-					<div class="border-danger-medium bg-danger-light rounded border p-2">
-						<ul class="text-danger-dark space-y-0.5">
-							{#each sceneBuilder.updateErrors as err (err.componentName)}
-								<li><span class="font-mono">{err.componentName}</span>: {err.reason}</li>
-							{/each}
-						</ul>
-					</div>
-				{/if}
+					{#if sceneBuilder.updateErrors.length > 0}
+						<div class="border-danger-medium bg-danger-light shrink-0 rounded border p-2">
+							<ul class="text-danger-dark space-y-0.5">
+								{#each sceneBuilder.updateErrors as err (err.componentName)}
+									<li class="flex min-w-0 gap-1">
+										<span
+											class="min-w-0 flex-1 overflow-hidden font-mono text-nowrap text-ellipsis"
+											title={err.componentName}>{err.componentName}</span
+										><span class="shrink-0">:</span><span>{err.reason}</span>
+									</li>
+								{/each}
+							</ul>
+						</div>
+					{/if}
 
-				<div class="mt-auto flex gap-2">
-					<button
-						class="rounded bg-gray-800 px-3 py-1.5 text-white hover:bg-gray-700"
-						onclick={sceneBuilder.confirm}
-					>
-						Confirm
-					</button>
-					<button
-						class="rounded border border-gray-300 px-3 py-1.5 hover:bg-gray-50"
-						onclick={sceneBuilder.cancel}
-					>
-						Cancel
-					</button>
+					<div class="mt-auto flex shrink-0 gap-2">
+						<button
+							class="rounded bg-gray-800 px-3 py-1.5 text-white hover:bg-gray-700"
+							onclick={sceneBuilder.confirm}
+						>
+							Apply
+						</button>
+						<button
+							class="rounded border border-gray-300 px-3 py-1.5 hover:bg-gray-50"
+							onclick={sceneBuilder.cancel}
+						>
+							Cancel
+						</button>
+					</div>
 				</div>
 			{/if}
 


### PR DESCRIPTION
These are the minimum fixes that Steve wanted so that we can put this feature back out and get feedback ASAP. Will consider doing accordion/selection style tables to make the information less crammed for multi-component diffs. 
- Explicit old vs. new diff headers, using prime colors used in the AI config assistant diffs. 
- "confirm" button --> "apply" for something more active. 
- Tooltip for cut off component names and diff explanations
- Added min width and min height for the floating panel to prevent over-shrinking.
- MISSING HERE: Clearer error state for instructions that try to add components. Since this is a deeper LLM config change, this was done in a separate PR #801 

Demo of a large instruction: 

https://github.com/user-attachments/assets/54e7e575-8e2a-421d-bf67-5ce3a8e3e0ee

