### PR TITLE
Allow mesh vertex colors

### DIFF
--- a/.changeset/crisp-parts-smash.md
+++ b/.changeset/crisp-parts-smash.md
@@ -1,0 +1,5 @@
+---
+"@viamrobotics/motion-tools": patch
+---
+
+Allow mesh vertex colors

--- a/src/lib/components/Entities/Mesh.svelte
+++ b/src/lib/components/Entities/Mesh.svelte
@@ -60,6 +60,14 @@
 		return colors.default
 	})
 
+	/**
+	 * PLY meshes from the world-state store carry per-vertex colors in the
+	 * geometry's `color` attribute. When present, render with `vertexColors`
+	 * enabled and a white base color so the material shows them untinted
+	 * (mirrors Points.svelte and Line.svelte).
+	 */
+	const hasVertexColors = $derived(bufferGeometry.current?.getAttribute('color') !== undefined)
+
 	const currentOpacity = $derived(opacity.current ?? 0.7)
 
 	let material = $state.raw<Material>(new Material())
@@ -143,7 +151,8 @@
 	{/if}
 
 	<T.MeshToonMaterial
-		{color}
+		color={hasVertexColors ? 0xffffff : color}
+		vertexColors={hasVertexColors}
 		side={bufferGeometry.current ? DoubleSide : FrontSide}
 		depthTest={materialProps.current?.depthTest ?? true}
 		oncreate={(m) => {

--- a/src/lib/components/Entities/Mesh.svelte
+++ b/src/lib/components/Entities/Mesh.svelte
@@ -60,12 +60,6 @@
 		return colors.default
 	})
 
-	/**
-	 * PLY meshes from the world-state store carry per-vertex colors in the
-	 * geometry's `color` attribute. When present, render with `vertexColors`
-	 * enabled and a white base color so the material shows them untinted
-	 * (mirrors Points.svelte and Line.svelte).
-	 */
 	const hasVertexColors = $derived(bufferGeometry.current?.getAttribute('color') !== undefined)
 
 	const currentOpacity = $derived(opacity.current ?? 0.7)


### PR DESCRIPTION
### Overview

`ply` files can have per vertex colors specified. Right now we ignore this, limiting the expressiveness of any meshes that contain meaningful vertex data. This PR adds per vertex color support:

<img width="736" height="643" alt="Screenshot 2026-07-02 at 16 28 10" src="https://github.com/user-attachments/assets/789dd30f-b59a-4bdf-94e7-864b20677b12" />
