### PR TITLE
Fix pointcloud object positions

### DIFF
--- a/.changeset/big-vans-rest.md
+++ b/.changeset/big-vans-rest.md
@@ -1,0 +1,5 @@
+---
+"@viamrobotics/motion-tools": patch
+---
+
+Fix pointcloud object positions

--- a/src/lib/hooks/usePointcloudObjects.svelte.ts
+++ b/src/lib/hooks/usePointcloudObjects.svelte.ts
@@ -7,6 +7,7 @@ import {
 	useResourceNames,
 } from '@viamrobotics/svelte-sdk'
 import { getContext, setContext, untrack } from 'svelte'
+import { Matrix4 } from 'three'
 
 import { createBufferGeometry, updateBufferGeometry } from '$lib/attribute'
 import { ColorFormat } from '$lib/buf/draw/v1/metadata_pb'
@@ -14,7 +15,7 @@ import { RefetchRates } from '$lib/components/overlay/RefreshRate.svelte'
 import { hierarchy, traits, useWorld } from '$lib/ecs'
 import { parsePcdInWorker } from '$lib/lib'
 import { useLogs } from '$lib/plugins'
-import { createPose } from '$lib/transform'
+import { createPose, poseToMatrix } from '$lib/transform'
 
 import { useEnvironment } from './useEnvironment.svelte'
 import { RefreshRates, useSettings } from './useSettings.svelte'
@@ -24,6 +25,9 @@ const key = Symbol('pointcloud-object-context')
 interface Context {
 	refetch: () => void
 }
+
+/** Scratch matrix for diffing an existing geometry's pose against its update. */
+const tempMatrix = new Matrix4()
 
 export const providePointcloudObjects = (partID: () => string) => {
 	const world = useWorld()
@@ -231,13 +235,18 @@ export const providePointcloudObjects = (partID: () => string) => {
 
 							if (existing) {
 								hierarchy.setParent(existing, geometriesInFrame.referenceFrame)
-								existing.set(traits.Center, center)
+								poseToMatrix(center, tempMatrix)
+								const matrix = existing.get(traits.Matrix)
+								if (matrix && !matrix.equals(tempMatrix)) {
+									matrix.copy(tempMatrix)
+									existing.changed(traits.Matrix)
+								}
 								traits.updateGeometryTrait(existing, geometry)
 							} else {
 								const entityTraits: ConfigurableTrait[] = [
 									traits.Name(geometryLabel),
 									...hierarchy.parentTraits(geometriesInFrame.referenceFrame),
-									traits.Center(center),
+									traits.Matrix(poseToMatrix(center, new Matrix4())),
 									traits.GeometriesAPI,
 									traits.Geometry(geometry),
 									traits.Opacity(0.2),

--- a/src/lib/hooks/usePointcloudObjects.svelte.ts
+++ b/src/lib/hooks/usePointcloudObjects.svelte.ts
@@ -26,8 +26,7 @@ interface Context {
 	refetch: () => void
 }
 
-/** Scratch matrix for diffing an existing geometry's pose against its update. */
-const tempMatrix = new Matrix4()
+const matrix4 = new Matrix4()
 
 export const providePointcloudObjects = (partID: () => string) => {
 	const world = useWorld()
@@ -235,10 +234,10 @@ export const providePointcloudObjects = (partID: () => string) => {
 
 							if (existing) {
 								hierarchy.setParent(existing, geometriesInFrame.referenceFrame)
-								poseToMatrix(center, tempMatrix)
+								poseToMatrix(center, matrix4)
 								const matrix = existing.get(traits.Matrix)
-								if (matrix && !matrix.equals(tempMatrix)) {
-									matrix.copy(tempMatrix)
+								if (matrix && !matrix.equals(matrix4)) {
+									matrix.copy(matrix4)
 									existing.changed(traits.Matrix)
 								}
 								traits.updateGeometryTrait(existing, geometry)


### PR DESCRIPTION
### Overview

At some point in the instanced rendering PR stack, I missed pointcloud objects, causing them to not be displayed in the correct location currently. This PR simply brings them up to speed with exactly how geometries are assembled in `useGeometries`, fixing any transform issues.


<img width="763" height="669" alt="Screenshot 2026-07-06 at 13 07 47" src="https://github.com/user-attachments/assets/951d3195-9f9c-42e2-8117-e36309475d77" />

