### PR TITLE
Cleanup geom typing

### DIFF
--- a/.changeset/fluffy-readers-rush.md
+++ b/.changeset/fluffy-readers-rush.md
@@ -1,0 +1,5 @@
+---
+'@viamrobotics/motion-tools': patch
+---
+
+Tighten geom typing (for LLM scene builder)

--- a/src/lib/geometry.ts
+++ b/src/lib/geometry.ts
@@ -20,40 +20,48 @@ export const createGeometry = (geometryType?: Geometry['geometryType'], label = 
 }
 
 export const createGeometryFromFrame = (frame: Partial<Frame>): Geometry | undefined => {
-	if (!frame.geometry) {
-		return
+	const geometry = frame.geometry
+	if (!geometry) {
+		return undefined
 	}
 
-	if (frame.geometry.type === 'box') {
-		return createGeometry({
-			case: 'box',
-			value: {
-				dimsMm: {
-					x: frame.geometry.x,
-					y: frame.geometry.y,
-					z: frame.geometry.z,
+	switch (geometry.type) {
+		case 'none': {
+			return undefined
+		}
+		case 'box': {
+			return createGeometry({
+				case: 'box',
+				value: {
+					dimsMm: {
+						x: geometry.x,
+						y: geometry.y,
+						z: geometry.z,
+					},
 				},
-			},
-		})
-	}
-
-	if (frame.geometry.type === 'sphere') {
-		return createGeometry({
-			case: 'sphere',
-			value: {
-				radiusMm: frame.geometry.r,
-			},
-		})
-	}
-
-	if (frame.geometry.type === 'capsule') {
-		return createGeometry({
-			case: 'capsule',
-			value: {
-				radiusMm: frame.geometry.r,
-				lengthMm: frame.geometry.l,
-			},
-		})
+			})
+		}
+		case 'sphere': {
+			return createGeometry({
+				case: 'sphere',
+				value: {
+					radiusMm: geometry.r,
+				},
+			})
+		}
+		case 'capsule': {
+			return createGeometry({
+				case: 'capsule',
+				value: {
+					radiusMm: geometry.r,
+					lengthMm: geometry.l,
+				},
+			})
+		}
+		default: {
+			const _exhaustive: never = geometry
+			return _exhaustive
+		}
 	}
 }
 

--- a/src/lib/plugins/LLMSceneBuilder/frameDeltaAdapter.ts
+++ b/src/lib/plugins/LLMSceneBuilder/frameDeltaAdapter.ts
@@ -1,6 +1,6 @@
 import type { Pose, Transform } from '@viamrobotics/sdk'
 
-import type { Frame } from '$lib/frame'
+import type { Frame, FrameGeometry } from '$lib/frame'
 import type { FragmentInfo } from '$lib/hooks/useFragmentInfo.svelte'
 import type { PartConfig } from '$lib/hooks/usePartConfig.svelte'
 
@@ -71,7 +71,7 @@ export interface FrameDelta {
 	// send that type's dims (box → x/y/z, sphere → r, capsule → r/l). `type: 'none'`
 	// removes the component's geometry.
 	geometry?: {
-		type?: 'none' | 'box' | 'sphere' | 'capsule'
+		type?: FrameGeometry
 		x?: number
 		y?: number
 		z?: number
@@ -160,37 +160,39 @@ function resolveGeometry(
 		return { error: 'Geometry change requires a type — the component has no existing geometry' }
 	}
 
-	if (type === 'box') {
-		const cur = current?.type === 'box' ? current : undefined
-		const x = delta.x ?? cur?.x
-		const y = delta.y ?? cur?.y
-		const z = delta.z ?? cur?.z
-		if (!isPositive(x) || !isPositive(y) || !isPositive(z)) {
-			return { error: 'Box geometry requires positive x, y, z dimensions' }
+	switch (type) {
+		case 'box': {
+			const cur = current?.type === 'box' ? current : undefined
+			const x = delta.x ?? cur?.x
+			const y = delta.y ?? cur?.y
+			const z = delta.z ?? cur?.z
+			if (!isPositive(x) || !isPositive(y) || !isPositive(z)) {
+				return { error: 'Box geometry requires positive x, y, z dimensions' }
+			}
+			return { geometry: { type: 'box', x, y, z } }
 		}
-		return { geometry: { type: 'box', x, y, z } }
-	}
-
-	if (type === 'sphere') {
-		const cur = current?.type === 'sphere' ? current : undefined
-		const r = delta.r ?? cur?.r
-		if (!isPositive(r)) {
-			return { error: 'Sphere geometry requires a positive radius r' }
+		case 'sphere': {
+			const cur = current?.type === 'sphere' ? current : undefined
+			const r = delta.r ?? cur?.r
+			if (!isPositive(r)) {
+				return { error: 'Sphere geometry requires a positive radius r' }
+			}
+			return { geometry: { type: 'sphere', r } }
 		}
-		return { geometry: { type: 'sphere', r } }
-	}
-
-	if (type === 'capsule') {
-		const cur = current?.type === 'capsule' ? current : undefined
-		const r = delta.r ?? cur?.r
-		const l = delta.l ?? cur?.l
-		if (!isPositive(r) || !isPositive(l)) {
-			return { error: 'Capsule geometry requires positive radius r and length l' }
+		case 'capsule': {
+			const cur = current?.type === 'capsule' ? current : undefined
+			const r = delta.r ?? cur?.r
+			const l = delta.l ?? cur?.l
+			if (!isPositive(r) || !isPositive(l)) {
+				return { error: 'Capsule geometry requires positive radius r and length l' }
+			}
+			return { geometry: { type: 'capsule', r, l } }
 		}
-		return { geometry: { type: 'capsule', r, l } }
+		default: {
+			const _exhaustive: never = type
+			return { error: `Unknown geometry type: ${_exhaustive}` }
+		}
 	}
-
-	return { error: `Unknown geometry type: ${type}` }
 }
 
 /**


### PR DESCRIPTION
## TLDR
FrameDelta['geometry'].type duplicated the four geometry-shape literals by hand instead of referencing FrameGeometry, and resolveGeometry/createGeometryFromFrame matched on shape type via if chains that silently fell through to a runtime error string or undefined on an unhandled case. This makes FrameGeometry (from frame.ts) the single source of truth for the delta's type field and converts both functions to exhaustive switch statements, so adding a new geometry shape (future additions) now fails to compile at both call sites until handled.

## Changes
-  Types FrameDelta['geometry'].type as FrameGeometry instead of a duplicated literal union
-  Converts resolveGeometry (frameDeltaAdapter.ts) and createGeometryFromFrame (geometry.ts) from if chains to exhaustive switch statements with never-check defaults

## Testing
- Run pnpm check and pnpm lint: both clean.
- Run pnpm vitest run: all 282 tests pass, including frameDeltaAdapter.spec.ts.