### PR TITLE
Fix sorting for instanced rendering

### DIFF
--- a/.changeset/thin-months-strive.md
+++ b/.changeset/thin-months-strive.md
@@ -1,0 +1,5 @@
+---
+"@viamrobotics/motion-tools": patch
+---
+
+Fix sorting for instanced rendering

--- a/src/lib/components/Entities/Boxes.svelte
+++ b/src/lib/components/Entities/Boxes.svelte
@@ -46,18 +46,15 @@ on each hit, which `useInstancedEntityEvents` maps back to the entity.
 	const unitBoxEdges = new EdgesGeometry(unitBox, 0)
 
 	/**
-	 * Box meshes render transparent by default (`Opacity` trait absent → 0.7,
-	 * depth write off — same as `Mesh.svelte`); per-instance alpha is written
-	 * via `setOpacityAt`. The base color stays white so per-instance colors
-	 * aren't tinted. Whole-object culling is disabled because the library
-	 * culls per instance against a bounding sphere it derives from each
-	 * instance matrix.
+	 * Box meshes render transparent by default (`Opacity` trait absent → 0.7);
+	 * per-instance alpha is written via `setOpacityAt`. The base color stays
+	 * white so per-instance colors aren't tinted. Whole-object culling is
+	 * disabled because the library culls per instance against a bounding sphere
+	 * it derives from each instance matrix.
 	 */
-	const instancedBoxes = new InstancedMesh2(
-		unitBox,
-		new MeshToonMaterial({ transparent: true, depthWrite: false }),
-		{ renderer }
-	)
+	const instancedBoxes = new InstancedMesh2(unitBox, new MeshToonMaterial({ transparent: true }), {
+		renderer,
+	})
 	instancedBoxes.sortObjects = true
 	instancedBoxes.customSort = createRadixSort(instancedBoxes)
 	instancedBoxes.frustumCulled = false

--- a/src/lib/components/Entities/Capsules.svelte
+++ b/src/lib/components/Entities/Capsules.svelte
@@ -62,19 +62,16 @@ pick the body or head id table and map the `instanceId` back to the entity.
 
 	/**
 	 * Build a faces mesh. Capsule meshes render transparent by default (`Opacity`
-	 * trait absent → 0.7, depth write off — same as the former per-entity
-	 * renderer); per-instance alpha is written via `setOpacityAt`. Whole-object
-	 * culling is disabled and the bounding sphere pinned open for the same reason
-	 * as `Boxes.svelte`: the library culls and raycasts per instance, and its
-	 * once-computed object sphere would otherwise gate an always-animating scene
-	 * shut.
+	 * trait absent → 0.7); per-instance alpha is written via `setOpacityAt`.
+	 * Whole-object culling is disabled and the bounding sphere pinned open for
+	 * the same reason as `Boxes.svelte`: the library culls and raycasts per
+	 * instance, and its once-computed object sphere would otherwise gate an
+	 * always-animating scene shut.
 	 */
 	const createFaces = (geometry: BufferGeometry) => {
-		const mesh = new InstancedMesh2(
-			geometry,
-			new MeshToonMaterial({ transparent: true, depthWrite: false }),
-			{ renderer }
-		)
+		const mesh = new InstancedMesh2(geometry, new MeshToonMaterial({ transparent: true }), {
+			renderer,
+		})
 		mesh.sortObjects = true
 		mesh.customSort = createRadixSort(mesh)
 		mesh.frustumCulled = false

--- a/src/lib/components/Entities/Entities.svelte
+++ b/src/lib/components/Entities/Entities.svelte
@@ -108,9 +108,10 @@
 
 <Arrows />
 <AxesHelpers />
-<Boxes />
+
 <Capsules />
 <Spheres />
+<Boxes />
 
 {#if enableLabels}
 	<Labels />

--- a/src/lib/components/Entities/Spheres.svelte
+++ b/src/lib/components/Entities/Spheres.svelte
@@ -47,16 +47,15 @@ on each hit, which `useInstancedEntityEvents` maps back to the entity.
 	const unitSphereEdges = new EdgesGeometry(unitSphere, 0)
 
 	/**
-	 * Sphere meshes render transparent by default (`Opacity` trait absent → 0.7,
-	 * depth write off — same as `Mesh.svelte`); per-instance alpha is written
-	 * via `setOpacityAt`. The base color stays white so per-instance colors
-	 * aren't tinted. Whole-object culling is disabled because the library
-	 * culls per instance against a bounding sphere it derives from each
-	 * instance matrix.
+	 * Sphere meshes render transparent by default (`Opacity` trait absent → 0.7);
+	 * per-instance alpha is written via `setOpacityAt`. The base color stays
+	 * white so per-instance colors aren't tinted. Whole-object culling is
+	 * disabled because the library culls per instance against a bounding sphere
+	 * it derives from each instance matrix.
 	 */
 	const instancedSpheres = new InstancedMesh2(
 		unitSphere,
-		new MeshToonMaterial({ transparent: true, depthWrite: false }),
+		new MeshToonMaterial({ transparent: true }),
 		{ renderer }
 	)
 	instancedSpheres.sortObjects = true


### PR DESCRIPTION
### Overview

This PR fixes an issue with sorting instanced objects introduced when we added InstancedMesh2. Our instancing implementation ported over the current material as is, which included a `depthWrite: false` option. This makes sense for better transparency sorting of individually rendered objects, but causes render sorting issues with instanced objects. In complex scenes, like some of the education demos, capsules that were behind boxes were rendering on top of them.