### PR TITLE
Fix transform controls & fragment editing

### DIFF
--- a/.changeset/sunny-chairs-beam.md
+++ b/.changeset/sunny-chairs-beam.md
@@ -1,0 +1,5 @@
+---
+"@viamrobotics/motion-tools": patch
+---
+
+Fix transform controls & fragment editing

--- a/src/lib/components/Entities/expandBoxByEntity.ts
+++ b/src/lib/components/Entities/expandBoxByEntity.ts
@@ -1,0 +1,50 @@
+import type { Entity } from 'koota'
+
+import { Box3, Matrix4, type Object3D, Vector3 } from 'three'
+
+import { traits } from '$lib/ecs'
+import { expandBoxByTransformedBox } from '$lib/three/OBBHelper'
+
+import { composeBoxMatrix } from './composeBoxMatrix'
+import { composeCapsuleBoundsMatrix } from './composeCapsuleMatrices'
+import { composeSphereBoundsMatrix } from './composeSphereMatrix'
+
+const matrix4 = new Matrix4()
+const unitBox = new Box3(new Vector3(-0.5, -0.5, -0.5), new Vector3(0.5, 0.5, 0.5))
+
+// Geometry-less frames have no bounds, so fall back to a small marker cube at
+// the frame origin — matching the selection marker in `Selected.svelte`.
+const referenceFrameScale = new Vector3(0.1, 0.1, 0.1)
+
+/**
+ * Expand `box` (world space) by an entity's bounds, resolving them the same way
+ * the selection overlays do — because `scene.getObjectByName` alone misses two
+ * common frame kinds:
+ *  - instanced primitives (box/sphere/capsule) carry no named object, so compose
+ *    the bounds straight from their traits,
+ *  - geometry-less reference frames render only an axes helper, so mark a small
+ *    cube at their `WorldMatrix` origin.
+ * A named scene object (meshes, points, lines) contributes its own geometry.
+ */
+export const expandBoxByEntity = (box: Box3, entity: Entity, scene: Object3D): void => {
+	if (
+		composeBoxMatrix(entity, matrix4) ||
+		composeCapsuleBoundsMatrix(entity, matrix4) ||
+		composeSphereBoundsMatrix(entity, matrix4)
+	) {
+		expandBoxByTransformedBox(box, unitBox, matrix4)
+		return
+	}
+
+	const object3d = scene.getObjectByName(entity as unknown as string)
+	if (object3d) {
+		box.expandByObject(object3d)
+		return
+	}
+
+	const world = entity.get(traits.WorldMatrix)
+	if (world) {
+		matrix4.copy(world).scale(referenceFrameScale)
+		expandBoxByTransformedBox(box, unitBox, matrix4)
+	}
+}

--- a/src/lib/components/Selected.svelte
+++ b/src/lib/components/Selected.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { T, useTask, useThrelte } from '@threlte/core'
-	import { BatchedMesh, Box3, Matrix4 } from 'three'
+	import { BatchedMesh, Box3, Matrix4, Vector3 } from 'three'
 	import { OBB } from 'three/addons/math/OBB.js'
 
 	import { composeBoxMatrix } from '$lib/components/Entities/composeBoxMatrix'
@@ -12,6 +12,11 @@
 	const box3 = new Box3()
 	const obb = new OBB()
 	const matrix4 = new Matrix4()
+
+	// Geometry-less frames have no bounds to measure, so a selected reference
+	// frame gets a small marker cube at its origin instead — roughly the size of
+	// the frame's axes helper — so the selection stays visible.
+	const referenceFrameScale = new Vector3(0.1, 0.1, 0.1)
 
 	const { scene, invalidate } = useThrelte()
 	const selected = useQuery(traits.Selected)
@@ -42,7 +47,17 @@
 				}
 
 				const object = scene.getObjectByName(entity as unknown as string)
-				if (!object) continue
+				if (!object) {
+					// Reference frames render only an instanced axes helper (no named
+					// object) and carry no primitive trait. Anchor a marker cube at the
+					// frame origin from its WorldMatrix so the selection is still shown.
+					const world = entity.get(traits.WorldMatrix)
+					if (world) {
+						matrix4.copy(world).scale(referenceFrameScale)
+						obbHelper.setFromMatrix4(matrix4)
+					}
+					continue
+				}
 
 				const instance = entity.get(traits.InstanceId)
 				if (instance !== undefined && instance >= 0 && object instanceof BatchedMesh) {

--- a/src/lib/components/SelectedTransformControls.svelte
+++ b/src/lib/components/SelectedTransformControls.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { T, useThrelte } from '@threlte/core'
 	import { TransformControls } from '@threlte/extras'
-	import { Group, MathUtils, Matrix4 } from 'three'
+	import { Group, Matrix4 } from 'three'
 
 	import type { FrameEditSession } from '$lib/editing/FrameEditSession'
 

--- a/src/lib/components/SelectedTransformControls.svelte
+++ b/src/lib/components/SelectedTransformControls.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { useThrelte } from '@threlte/core'
+	import { T, useThrelte } from '@threlte/core'
 	import { TransformControls } from '@threlte/extras'
-	import { Matrix4 } from 'three'
+	import { Group, MathUtils, Matrix4 } from 'three'
 
 	import type { FrameEditSession } from '$lib/editing/FrameEditSession'
 
@@ -13,7 +13,7 @@
 	import { useSettings } from '$lib/hooks/useSettings.svelte'
 	import { createPose, matrixToPose, poseToMatrix, solveEditedMatrix } from '$lib/transform'
 
-	const { scene } = useThrelte()
+	const { invalidate } = useThrelte()
 	const settings = useSettings()
 	const environment = useEnvironment()
 	const fragmentInfo = useFragmentInfo()
@@ -23,11 +23,11 @@
 
 	const mode = $derived(settings.current.transformMode)
 	const entity = $derived(selected.current[0])
-	const object3d = $derived(scene.getObjectByName(entity as unknown as string))
 	const transformable = useTrait(() => entity, traits.Transformable)
 	const invisible = useTrait(() => entity, traits.InheritedInvisible)
 	const configMatrix = useTrait(() => entity, traits.Matrix)
 	const liveMatrix = useTrait(() => entity, traits.LiveMatrix)
+	const worldMatrix = useTrait(() => entity, traits.WorldMatrix)
 	const box = useTrait(() => entity, traits.Box)
 	const sphere = useTrait(() => entity, traits.Sphere)
 	const capsule = useTrait(() => entity, traits.Capsule)
@@ -39,11 +39,29 @@
 		name.current && Object.keys(fragmentInfo.current?.[name.current]?.variables ?? {}).length > 0
 	)
 
-	// Mesh sets name={entity} on its inner mesh, so getObjectByName resolves
-	// to that mesh — not the parent Frame Group we actually want to drive. Walk
-	// up to the Group so translate/rotate/scale apply to the whole frame, not
-	// the geometry inside it.
-	const ref = $derived(object3d?.parent ?? object3d)
+	// Non-mesh frames (reference frames, and instanced box/sphere/capsule frames)
+	// render no named scene object, so `getObjectByName` can't locate a gizmo
+	// target. Drive a dedicated anchor Group from the selected entity's
+	// WorldMatrix instead — the same world transform the entity renderers
+	// compose. They mount at the scene root with `matrixAutoUpdate = false`, so
+	// this anchor's world-space transform matches theirs exactly.
+	const anchor = new Group()
+	anchor.matrixAutoUpdate = false
+
+	$effect.pre(() => {
+		const world = worldMatrix.current
+		if (!world) return
+
+		anchor.matrix.copy(world)
+		// Keep position/quaternion/scale in sync with the matrix so
+		// TransformControls (which reads/writes those fields) sees the entity's
+		// actual transform on drag start.
+		anchor.matrix.decompose(anchor.position, anchor.quaternion, anchor.scale)
+		anchor.updateMatrixWorld()
+		invalidate()
+	})
+
+	const ref = $derived(worldMatrix.current ? anchor : undefined)
 
 	const activeMode = $derived.by<'translate' | 'rotate' | 'scale' | undefined>(() => {
 		if (mode === 'none' || !transformable.current) return
@@ -268,6 +286,10 @@
 </script>
 
 {#if transforming}
+	<T
+		is={anchor}
+		dispose={false}
+	/>
 	{#key entity}
 		<TransformControls
 			object={ref}

--- a/src/lib/components/overlay/Details.svelte
+++ b/src/lib/components/overlay/Details.svelte
@@ -2,7 +2,7 @@
 	module
 	lang="ts"
 >
-	import { BufferAttribute, MathUtils } from 'three'
+	import { Box3, BufferAttribute, MathUtils } from 'three'
 </script>
 
 <script lang="ts">
@@ -26,6 +26,7 @@
 		TabPage,
 	} from 'svelte-tweakpane-ui'
 
+	import { expandBoxByEntity } from '$lib/components/Entities/expandBoxByEntity'
 	import AddRelationship from '$lib/components/overlay/AddRelationship.svelte'
 	import AxesHelperDetails from '$lib/components/overlay/details/AxesHelperDetails.svelte'
 	import OpacityDetails from '$lib/components/overlay/details/OpacityDetails.svelte'
@@ -80,6 +81,19 @@
 	const framesAPI = useTrait(() => entity, traits.FramesAPI)
 	const geometriesAPI = useTrait(() => entity, traits.GeometriesAPI)
 	const customDetails = useTag(() => entity, traits.CustomDetails)
+
+	// Fit-to-view needs world bounds. `object3d` alone is undefined for instanced
+	// primitives and geometry-less frames, so resolve bounds via the shared
+	// helper (traits / named object / WorldMatrix) and only offer the button when
+	// something is resolvable.
+	const focusBox = new Box3()
+	const focusable = $derived(
+		object3d !== undefined ||
+			box.current !== undefined ||
+			sphere.current !== undefined ||
+			capsule.current !== undefined ||
+			worldMatrix.current !== undefined
+	)
 
 	const localPose = $derived.by<Pose | undefined>(() => {
 		const source = editedMatrix.current ?? matrix.current
@@ -260,7 +274,7 @@
 				<span class="text-subtle-2">{displayType}</span>
 			</div>
 
-			{#if object3d}
+			{#if focusable}
 				<Tooltip
 					let:tooltipID
 					location="bottom"
@@ -275,9 +289,13 @@
 
 							if (!currentControls || !('fitToBox' in currentControls)) return
 
+							focusBox.makeEmpty()
+							expandBoxByEntity(focusBox, entity, scene)
+							if (focusBox.isEmpty()) return
+
 							const { azimuthAngle, polarAngle } = currentControls
 
-							currentControls.fitToBox(object3d, true, {
+							currentControls.fitToBox(focusBox, true, {
 								paddingTop: padding,
 								paddingBottom: padding,
 								paddingLeft: padding,

--- a/src/lib/hooks/useFragmentInfo.svelte.ts
+++ b/src/lib/hooks/useFragmentInfo.svelte.ts
@@ -47,6 +47,33 @@ export const useFragmentInfo = (): FragmentInfoContext => {
 	return getContext<FragmentInfoContext>(key)
 }
 
+/**
+ * Extract the component names a `fragment_mods` list targets, from dot-notation
+ * mod paths like `components.<name>.frame` or `components.<name>.attributes.*`.
+ * A component only appears here if a fragment provides it, so its presence maps
+ * the component to that mod's fragment.
+ */
+const moddedComponentNames = (mods: unknown[]): string[] => {
+	const names: string[] = []
+	for (const mod of mods) {
+		if (!mod || typeof mod !== 'object') {
+			continue
+		}
+		for (const opValue of Object.values(mod as Record<string, unknown>)) {
+			if (!opValue || typeof opValue !== 'object') {
+				continue
+			}
+			for (const path of Object.keys(opValue as Record<string, unknown>)) {
+				const match = /^components\.([^.]+)/.exec(path)
+				if (match) {
+					names.push(match[1])
+				}
+			}
+		}
+	}
+	return names
+}
+
 const useStandaloneFragmentInfo = (partID: () => string): FragmentInfoContext => {
 	const partQuery = createAppQuery('getRobotPart', () => [partID()] as const, {
 		refetchInterval: false,
@@ -112,6 +139,29 @@ const useStandaloneFragmentInfo = (partID: () => string): FragmentInfoContext =>
 							results[componentName.value] = fragmentInfo
 						}
 					}
+				}
+			}
+		}
+
+		// A component this part targets via `fragment_mods` is, by definition,
+		// provided by that mod's fragment — even when `getFragment` doesn't surface
+		// it as a top-level `components` entry (e.g. it comes from a nested
+		// fragment). Map those names too so their frame edits route to the fragment
+		// path (`updateFragmentFrame`) instead of silently no-opping against the
+		// part's own components. Fragment-component matches above keep priority
+		// since they also carry the base `frame`.
+		const fragmentMods = (configJSON?.['fragment_mods'] ?? []) as {
+			fragment_id?: string
+			mods?: unknown[]
+		}[]
+		for (const { fragment_id: modFragmentId, mods } of fragmentMods) {
+			if (!modFragmentId || !mods) {
+				continue
+			}
+			for (const name of moddedComponentNames(mods)) {
+				results[name] ??= {
+					id: modFragmentId,
+					variables: fragmentIdToVariables[modFragmentId] ?? {},
 				}
 			}
 		}

--- a/src/lib/plugins/Focus/FocusBox.svelte
+++ b/src/lib/plugins/Focus/FocusBox.svelte
@@ -2,15 +2,12 @@
 	import { T, useThrelte } from '@threlte/core'
 	import { Gizmo, TrackballControls } from '@threlte/extras'
 	import { untrack } from 'svelte'
-	import { Box3, Matrix4, Vector3 } from 'three'
+	import { Box3, Vector3 } from 'three'
 
 	import Camera from '$lib/components/Camera.svelte'
-	import { composeBoxMatrix } from '$lib/components/Entities/composeBoxMatrix'
-	import { composeCapsuleBoundsMatrix } from '$lib/components/Entities/composeCapsuleMatrices'
-	import { composeSphereBoundsMatrix } from '$lib/components/Entities/composeSphereMatrix'
+	import { expandBoxByEntity } from '$lib/components/Entities/expandBoxByEntity'
 	import { traits, useQuery } from '$lib/ecs'
 	import { useCameraControls } from '$lib/hooks/useControls.svelte'
-	import { expandBoxByTransformedBox } from '$lib/three/OBBHelper'
 
 	const { scene } = useThrelte()
 	const cameraControls = useCameraControls()
@@ -39,8 +36,6 @@
 
 	const box = new Box3()
 	const vec = new Vector3()
-	const unitBox = new Box3(new Vector3(-0.5, -0.5, -0.5), new Vector3(0.5, 0.5, 0.5))
-	const matrix4 = new Matrix4()
 
 	let center = $state.raw<[number, number, number]>([0, 0, 0])
 	let size = $state.raw<[number, number, number]>([0, 0, 0])
@@ -54,27 +49,7 @@
 	$effect(() => {
 		box.makeEmpty()
 		for (const entity of untrack(() => selected.current)) {
-			// Boxes, capsules, and spheres render instanced, so the entity's named
-			// scene object carries no geometry — frame them from traits instead.
-			if (composeBoxMatrix(entity, matrix4)) {
-				expandBoxByTransformedBox(box, unitBox, matrix4)
-				continue
-			}
-
-			if (composeCapsuleBoundsMatrix(entity, matrix4)) {
-				expandBoxByTransformedBox(box, unitBox, matrix4)
-				continue
-			}
-
-			if (composeSphereBoundsMatrix(entity, matrix4)) {
-				expandBoxByTransformedBox(box, unitBox, matrix4)
-				continue
-			}
-
-			const object3d = scene.getObjectByName(entity as unknown as string)
-			if (object3d) {
-				box.expandByObject(object3d)
-			}
+			expandBoxByEntity(box, entity, scene)
 		}
 
 		size = box.getSize(vec).toArray()


### PR DESCRIPTION
### Overview

This PR fixes an issue that silently popped up during instanced rendering updates and was exposed by https://github.com/viamrobotics/visualization/pull/821. The selected transform controls anchor themselves to Object3Ds, which no longer exist with instanced rendering. However, before the cleanup PR, ghost object3Ds were still being created via the `<Frame>` component that the selected transform controls could anchor to. The cleanup PR removed those and broke transform controls. This PR switches these controls over to use `WorldMatrix` like everything else, fixing the issue.

When fixing this, I discovered another fragment editing bug - fixed here - that recently became apparent due to vino2 config changes. Fragment tagging was incomplete in some scenarios when reading from the robot config, causing transform changes to not trigger the isDirty flag.

More details in comments.
