### PR TITLE
Snapping and local transform improvements

### DIFF
--- a/.changeset/forty-berries-dig.md
+++ b/.changeset/forty-berries-dig.md
@@ -1,0 +1,5 @@
+---
+"@viamrobotics/motion-tools": patch
+---
+
+Snapping and local transform improvements

--- a/src/lib/components/SelectedTransformControls.svelte
+++ b/src/lib/components/SelectedTransformControls.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { T, useThrelte } from '@threlte/core'
 	import { TransformControls } from '@threlte/extras'
-	import { Group, Matrix4 } from 'three'
+	import { Group, Matrix4, MathUtils } from 'three'
 
 	import type { FrameEditSession } from '$lib/editing/FrameEditSession'
 
@@ -294,9 +294,16 @@
 		<TransformControls
 			object={ref}
 			mode={activeMode}
-			translationSnap={settings.current.snapping ? 0.1 : undefined}
-			rotationSnap={settings.current.snapping ? Math.PI / 24 : undefined}
-			scaleSnap={settings.current.snapping ? 0.1 : undefined}
+			space={settings.current.transformSpace}
+			translationSnap={settings.current.snapping && settings.current.snapTranslate > 0
+				? settings.current.snapTranslate
+				: null}
+			rotationSnap={settings.current.snapping && settings.current.snapRotate > 0
+				? MathUtils.degToRad(settings.current.snapRotate)
+				: null}
+			scaleSnap={settings.current.snapping && settings.current.snapScale > 0
+				? settings.current.snapScale
+				: null}
 			showY={!isSphereScale}
 			showZ={!isSphereScale && !isCapsuleScale}
 			onmouseDown={onMouseDown}

--- a/src/lib/components/SelectedTransformControls.svelte
+++ b/src/lib/components/SelectedTransformControls.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { T, useThrelte } from '@threlte/core'
 	import { TransformControls } from '@threlte/extras'
-	import { Group, Matrix4, MathUtils } from 'three'
+	import { Group, MathUtils, Matrix4 } from 'three'
 
 	import type { FrameEditSession } from '$lib/editing/FrameEditSession'
 

--- a/src/lib/components/overlay/dashboard/Button.svelte
+++ b/src/lib/components/overlay/dashboard/Button.svelte
@@ -6,6 +6,7 @@
 
 	interface Props extends HTMLButtonAttributes {
 		icon: IconName | 'ruler' | 'mouse-pointer' | 'shapes' | 'focus'
+		iconCx?: string
 		active?: boolean
 		description: string
 		hotkey?: string
@@ -17,6 +18,7 @@
 
 	let {
 		icon,
+		iconCx,
 		active = false,
 		description,
 		hotkey = '',
@@ -58,7 +60,10 @@
 			{:else if icon === 'focus'}
 				<Focus size="16" />
 			{:else}
-				<Icon name={icon} />
+				<Icon
+					name={icon}
+					cx={iconCx}
+				/>
 			{/if}
 		</button>
 	</label>

--- a/src/lib/components/overlay/dashboard/Dashboard.svelte
+++ b/src/lib/components/overlay/dashboard/Dashboard.svelte
@@ -1,9 +1,11 @@
 <script>
 	import { PortalTarget } from '@threlte/extras'
+	import { Slider } from 'svelte-tweakpane-ui'
 
 	import { useSettings } from '$lib/hooks/useSettings.svelte'
 
 	import Button from './Button.svelte'
+	import DropdownPane from './DropdownPane.svelte'
 
 	let { dashboard, ...rest } = $props()
 
@@ -59,14 +61,76 @@
 	</fieldset>
 
 	<!-- snapping -->
-
 	<fieldset class="flex">
 		<Button
 			icon={settings.current.snapping ? 'magnet' : 'magnet-off'}
+			class="rounded-r-none"
 			active={settings.current.snapping}
 			description="Snapping"
 			onclick={() => {
 				settings.current.snapping = !settings.current.snapping
+			}}
+		/>
+		<DropdownPane
+			title="Snapping"
+			active={settings.current.snapping}
+			description="Snapping settings"
+		>
+			<Slider
+				label="Move"
+				min={0}
+				step={0.01}
+				value={settings.current.snapTranslate}
+				on:change={(event) => {
+					if (event.detail.origin === 'internal') {
+						settings.current.snapTranslate = event.detail.value
+					}
+				}}
+			/>
+			<Slider
+				label="Rotate"
+				min={0}
+				step={0.5}
+				format={(value) => `${value}°`}
+				value={settings.current.snapRotate}
+				on:change={(event) => {
+					if (event.detail.origin === 'internal') {
+						settings.current.snapRotate = event.detail.value
+					}
+				}}
+			/>
+			<Slider
+				label="Scale"
+				min={0}
+				step={0.01}
+				value={settings.current.snapScale}
+				on:change={(event) => {
+					if (event.detail.origin === 'internal') {
+						settings.current.snapScale = event.detail.value
+					}
+				}}
+			/>
+		</DropdownPane>
+	</fieldset>
+
+	<!-- space -->
+	<fieldset class="flex">
+		<Button
+			icon="axis-arrow"
+			class="rounded-r-none"
+			active={settings.current.transformSpace === 'local'}
+			description="Local space"
+			onclick={() => {
+				settings.current.transformSpace = 'local'
+			}}
+		/>
+		<Button
+			icon="earth"
+			class="-ml-px rounded-l-none"
+			active={settings.current.transformSpace === 'world'}
+			description="World space"
+			onclick={() => {
+				settings.current.transformSpace = 'world'
 			}}
 		/>
 	</fieldset>

--- a/src/lib/components/overlay/dashboard/DropdownPane.svelte
+++ b/src/lib/components/overlay/dashboard/DropdownPane.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte'
+
+	import { Pane } from 'svelte-tweakpane-ui'
+
+	import Popover from '$lib/components/overlay/Popover.svelte'
+
+	import Button from './Button.svelte'
+
+	interface Props {
+		title: string
+		active?: boolean
+		description?: string
+		children: Snippet
+	}
+
+	let { title, active = false, description, children }: Props = $props()
+</script>
+
+<Popover>
+	{#snippet trigger(triggerProps, { isOpen })}
+		<Button
+			{...triggerProps}
+			{active}
+			class="rounded-l-none border-l-0"
+			icon="chevron-down"
+			iconCx="motion-safe:transition-transform {isOpen ? 'rotate-180' : ''}"
+			description={description ?? title}
+		/>
+	{/snippet}
+
+	<Pane
+		position="inline"
+		{title}
+		expanded
+		userExpandable={false}
+	>
+		{@render children()}
+	</Pane>
+</Popover>

--- a/src/lib/hooks/useSettings.svelte.ts
+++ b/src/lib/hooks/useSettings.svelte.ts
@@ -20,7 +20,11 @@ export interface Settings {
 
 	// Transform controls
 	snapping: boolean
+	snapTranslate: number
+	snapRotate: number
+	snapScale: number
 	transformMode: 'none' | 'translate' | 'rotate' | 'scale'
+	transformSpace: 'local' | 'world'
 
 	// Grid
 	grid: boolean
@@ -97,7 +101,11 @@ const defaults = (): Settings => ({
 	disabledVisionServices: {},
 
 	snapping: false,
+	snapTranslate: 0.1,
+	snapRotate: 7.5,
+	snapScale: 0.1,
 	transformMode: 'none',
+	transformSpace: 'world',
 
 	grid: true,
 	gridCellSize: 0.5,

--- a/src/lib/plugins/MeasureTool/MeasureTool.svelte
+++ b/src/lib/plugins/MeasureTool/MeasureTool.svelte
@@ -2,11 +2,12 @@
 	import { T } from '@threlte/core'
 	import { HTML, MeshLineGeometry, MeshLineMaterial } from '@threlte/extras'
 	import { untrack } from 'svelte'
+	import { Element } from 'svelte-tweakpane-ui'
 	import { type Intersection, Vector3 } from 'three'
 
 	import { DashboardPortal } from '$lib'
 	import Button from '$lib/components/overlay/dashboard/Button.svelte'
-	import Popover from '$lib/components/overlay/Popover.svelte'
+	import DropdownPane from '$lib/components/overlay/dashboard/DropdownPane.svelte'
 	import ToggleGroup from '$lib/components/overlay/ToggleGroup.svelte'
 	import { useMouseRaycaster } from '$lib/hooks/useMouseRaycaster.svelte'
 	import { useSettings } from '$lib/hooks/useSettings.svelte'
@@ -90,20 +91,14 @@
 					settings.current.interactionMode = enabled ? 'navigate' : 'measure'
 				}}
 			/>
-			<Popover>
-				{#snippet trigger(triggerProps)}
-					<Button
-						{...triggerProps}
-						active={enabled}
-						class="rounded-l-none border-l-0"
-						icon="filter-sliders"
-						description="Measurement settings"
-					/>
-				{/snippet}
-
-				<div class="border-medium m-2 border bg-white p-2 text-xs">
-					<div class="flex items-center gap-2">
-						Enabled axes
+			<DropdownPane
+				title="Measurement"
+				active={enabled}
+				description="Measurement axes"
+			>
+				<Element>
+					<div class="font-public-sans text-subtle-1 flex items-center gap-2 text-xs">
+						<span>Axes</span>
 						<ToggleGroup
 							multiple
 							options={[
@@ -118,8 +113,8 @@
 							}}
 						/>
 					</div>
-				</div>
-			</Popover>
+				</Element>
+			</DropdownPane>
 		</div>
 	</fieldset>
 </DashboardPortal>


### PR DESCRIPTION
### Overview

This PR introduces improvements to the snapping feature for transforming, and introduces a new local transform feature.

### Snapping 
Snapping now allows users to set their snap values: 

<img width="863" height="519" alt="Screenshot 2026-07-09 at 13 45 08" src="https://github.com/user-attachments/assets/e109caa3-4c65-48bc-818a-90e786ba7156" />
<br>

### Transforming 
Local transforming allows users to translate objects along their local axes instead of global axes:

<img width="681" height="582" alt="Screenshot 2026-07-09 at 13 46 14" src="https://github.com/user-attachments/assets/a31ffdbb-07e2-475a-a5ea-3eedaa7ff7d7" />
