### PR TITLE
update perf monitor

### DIFF
--- a/.changeset/curly-heads-search.md
+++ b/.changeset/curly-heads-search.md
@@ -1,0 +1,5 @@
+---
+'@viamrobotics/motion-tools': patch
+---
+
+Fix perf monitor in embedded environments with blocking CSPs.

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: verify
+description: Build, launch, and drive the visualizer to verify a change end-to-end at its rendered surface.
+---
+
+# Verify a change in the running visualizer
+
+## Build + launch
+
+```bash
+pnpm run up   # wireit: vite-build + go-build, then bun static server (5173) + draw-server (3030)
+```
+
+- **Never invoke it as bare `pnpm up`** — pnpm treats `up` as the built-in
+  `update` alias and mutates package.json/pnpm-lock.yaml instead of running
+  the wireit script. Always `pnpm run up` (`make up` does this).
+- Server is ready when `curl -s http://localhost:5173/` returns 200
+  (~30-60s cold build).
+- The bun server serves exact files from `build/` — routes need `.html`:
+  `http://localhost:5173/snapshot.html` (self-contained demo scene, loads
+  `/visualization_snapshot.json`, no robot required). `/snapshot` 404s.
+
+## Drive it
+
+Playwright is available via the repo's `@playwright/test` devDep. Scripts
+must live inside the repo root for module resolution:
+
+```js
+import { chromium } from '@playwright/test'
+```
+
+Useful selectors on the snapshot page:
+
+- Dashboard buttons use `aria-label` = their description, e.g.
+  `[aria-label="Settings"]`.
+- Settings panel tabs are text labels: Connection / Scene / Debug / etc.
+- Debug tab has a "Render stats" `<Switch>` (toggles the three-perf
+  monitor, `#three-perf-ui`).
+- Robot-query console errors (`[viam-svelte-sdk] error … getPose …`) are
+  expected offline noise on the snapshot page; the SvelteKit router also
+  logs one `Not found: /snapshot.html` — both harmless.
+
+## Gotchas
+
+- Settings persist via localStorage per browser context; fresh Playwright
+  contexts start from defaults.
+- Rendering is on-demand: after toggling scene settings give it ~1-2s
+  before screenshotting.
+- Sentry replay, GLTF/basis, and the PCD loader pool create blob workers
+  at startup — don't mistake them for the code under test when
+  intercepting `window.Worker`.

--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,4 @@ setup:
 	@./etc/setup.sh
 
 up:
-	@pnpm up
+	@pnpm run up

--- a/package.json
+++ b/package.json
@@ -452,10 +452,10 @@
 		"@changesets/cli": "2.29.6",
 		"@connectrpc/connect": "1.7.0",
 		"@connectrpc/connect-web": "1.7.0",
-		"@langchain/anthropic": "^1.4.0",
 		"@dimforge/rapier3d-compat": "0.18.2",
 		"@eslint/compat": "2.0.2",
 		"@eslint/js": "10.0.1",
+		"@langchain/anthropic": "^1.4.0",
 		"@playwright/test": "1.55.1",
 		"@sentry/sveltekit": "10.10.0",
 		"@skeletonlabs/skeleton": "3.2.0",
@@ -632,6 +632,8 @@
 		"koota": "0.6.5",
 		"lodash-es": "4.18.1",
 		"three-mesh-bvh": "^0.9.8",
+		"three-perf": "^1.0.11",
+		"troika-three-text": "^0.52.4",
 		"uuid-tool": "^2.0.3"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,12 @@ importers:
       three-mesh-bvh:
         specifier: ^0.9.8
         version: 0.9.8(three@0.183.2)
+      three-perf:
+        specifier: ^1.0.11
+        version: 1.0.11(three@0.183.2)
+      troika-three-text:
+        specifier: ^0.52.4
+        version: 0.52.4(three@0.183.2)
       uuid-tool:
         specifier: ^2.0.3
         version: 2.0.3

--- a/src/lib/components/App.svelte
+++ b/src/lib/components/App.svelte
@@ -1,3 +1,25 @@
+<script
+	lang="ts"
+	module
+>
+	import { configureTextBuilder } from 'troika-three-text'
+
+	// Embedding hosts (e.g. app.viam.com) can serve a Content-Security-Policy
+	// that blocks the `blob:` worker troika-three-text typesets in, which
+	// leaves every troika Text mesh blank — the perf monitor counters, XR
+	// labels, etc. The visualizer only renders short labels, so typeset on
+	// the main thread instead of depending on host CSP allowing blob workers.
+	// Troika ignores configuration changes after its first font request, so
+	// this must run before the first Text renders.
+	//
+	// Note: troika's CONFIG is a process-global singleton, so this switches
+	// every troika Text on the page to main-thread typesetting, not just the
+	// visualizer's own meshes. That is intended (it also rescues any troika
+	// text a CSP host renders itself); the only cost on a non-CSP host is
+	// losing worker offload, which is negligible for our short labels.
+	configureTextBuilder({ useWorker: false })
+</script>
+
 <script lang="ts">
 	import type { Struct } from '@viamrobotics/sdk'
 	import type { Entity } from 'koota'

--- a/src/lib/components/PerfMonitor.svelte
+++ b/src/lib/components/PerfMonitor.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+	import { useStage, useTask, useThrelte } from '@threlte/core'
+	import { ThreePerf } from 'three-perf'
+
+	interface Props {
+		logsPerSecond?: number
+		showGraph?: boolean
+		memory?: boolean
+		enabled?: boolean
+		visible?: boolean
+		backgroundOpacity?: number
+		scale?: number
+		anchorX?: 'left' | 'right'
+		anchorY?: 'top' | 'bottom'
+	}
+
+	let {
+		logsPerSecond = 10,
+		showGraph = true,
+		memory = true,
+		enabled = true,
+		visible = true,
+		backgroundOpacity = 0.7,
+		scale = 1,
+		anchorX = 'left',
+		anchorY = 'top',
+	}: Props = $props()
+
+	const { dom, renderer, renderStage, mainStage } = useThrelte()
+
+	let perf: ThreePerf
+
+	$effect.pre(() => {
+		perf = new ThreePerf({
+			domElement: dom,
+			renderer,
+		})
+
+		// three-perf hardcodes `position: fixed`, which anchors the monitor to
+		// the viewport even when the visualizer is embedded in a larger page.
+		// Anchor it to Threlte's relative-positioned canvas wrapper instead.
+		perf.ui.wrapper.style.position = 'absolute'
+
+		// Overlay panels (Details, FloatingPanel) share this corner at z-4/z-5;
+		// keep the debug monitor above them so toggling it on is never a no-op,
+		// but below the top-layer fullscreen/file-drop overlays.
+		perf.ui.wrapper.style.zIndex = '10'
+
+		return () => perf.dispose()
+	})
+
+	$effect.pre(() => {
+		perf.logsPerSecond = logsPerSecond
+		perf.showGraph = showGraph
+		perf.memory = memory
+		perf.enabled = enabled
+		perf.visible = visible
+		perf.backgroundOpacity = backgroundOpacity
+		perf.scale = scale
+		perf.anchorX = anchorX
+		perf.anchorY = anchorY
+	})
+
+	useTask(
+		() => {
+			perf.begin()
+		},
+		{
+			stage: useStage('monitor-begin', {
+				before: mainStage,
+			}),
+		}
+	)
+
+	useTask(
+		() => {
+			perf.end()
+		},
+		{
+			stage: useStage('monitor-end', {
+				after: renderStage,
+			}),
+		}
+	)
+</script>

--- a/src/lib/components/Scene.svelte
+++ b/src/lib/components/Scene.svelte
@@ -2,12 +2,13 @@
 	import type { Snippet } from 'svelte'
 
 	import { T, useThrelte } from '@threlte/core'
-	import { Environment, Grid, interactivity, PerfMonitor, PortalTarget } from '@threlte/extras'
+	import { Environment, Grid, interactivity, PortalTarget } from '@threlte/extras'
 	import { useXR } from '@threlte/xr'
 	import { ShaderMaterial } from 'three'
 
 	import Camera from '$lib/components/Camera.svelte'
 	import Entities from '$lib/components/Entities/Entities.svelte'
+	import PerfMonitor from '$lib/components/PerfMonitor.svelte'
 	import Selected from '$lib/components/Selected.svelte'
 	import SelectedTransformControls from '$lib/components/SelectedTransformControls.svelte'
 	import StaticGeometries from '$lib/components/StaticGeometries.svelte'

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -6,3 +6,8 @@ declare const BACKEND_IP: string
 declare const WS_PORT: string
 
 declare module '*.hdr'
+
+// troika-three-text ships no type declarations; declare the one API we use.
+declare module 'troika-three-text' {
+	export function configureTextBuilder(config: { useWorker?: boolean }): void
+}


### PR DESCRIPTION
Fixes the three-perf performance monitor when the visualizer is embedded in a host page that serves a strict Content-Security-Policy (for example app.viam.com). Previously the monitor anchored to the corner of the whole viewport instead of the visualizer container, and its numeric counters (GPU/CPU/FPS plus the geometry/texture/shader stats) were blank while only the line graphs drew.

### Frontend

- `PerfMonitor.svelte` (new): a local replacement for `@threlte/extras`'s `PerfMonitor`. It mounts three-perf into Threlte's canvas wrapper (`useThrelte().dom`) instead of `document.body`, overrides three-perf's hardcoded `position: fixed` to `absolute` so the monitor anchors to the visualizer container, and sets `z-index: 10` so it sits above the overlay panels (Details and FloatingPanel at `z-4`/`z-5`) that share its top-right corner but below the fullscreen and file-drop layers.
- `Scene.svelte`: render the local `PerfMonitor` instead of the one from `@threlte/extras`.
- `App.svelte`: call `configureTextBuilder({ useWorker: false })` from `troika-three-text` in the component's `module` script so troika typesets text on the main thread instead of in a `blob:` worker. It runs on import, before any troika `Text` mounts, which is required because troika ignores the setting after its first font request. Note this switches every troika `Text` on the page to main-thread typesetting, which is intended.
- `vite-env.d.ts`: ambient module declaration for `troika-three-text`, which ships no types, covering the single export we import.
- `package.json`: add `three-perf` and `troika-three-text` as direct dependencies. Both were already present transitively (three-perf via `@threlte/extras`, troika via both), declaring them matches the new direct imports, and they dedupe to a single `troika-three-text@0.52.4`.

Two changes outside `src/`: a drive-by fix to the `Makefile` `up` target, which ran `pnpm up` (pnpm resolves bare `up` to its built-in `update` alias, so it mutated `package.json`/`pnpm-lock.yaml` instead of running the `up` script) and now runs `pnpm run up`, and a new `.claude/skills/verify` guide documenting how to build and drive the app locally.

### Why?

**Why disable troika's worker instead of allowing it in the host CSP?**

troika-worker-utils loads its worker in two stages: it creates the worker from a small bootstrap `blob:`, then the worker calls `importScripts()` on a second `blob:` URL to pull in the real typesetting code. A strict host CSP allows the first step (worker creation, governed by `worker-src`) but blocks the second (`importScripts` of a `blob:`, governed by the worker's `script-src`), so the worker starts, fails to load its code, and every troika `Text` renders blank. This is also why troika's own `supportsWorkers()` fallback does not save it: it only checks whether `new Worker()` throws synchronously, which succeeds, so troika commits to the worker path and only fails later in stage two. Relaxing the host CSP is the wrong fix. We do not own that policy, it would have to be repeated for every host that embeds the visualizer, and adding `blob:` to `script-src` weakens the host's XSS posture just so a debug overlay can typeset numbers off the main thread. Disabling the worker makes the library self-sufficient on any host, and the cost is negligible here: we render only short labels, and the expensive part (SDF glyph generation) already runs on the main thread via WebGL regardless of this setting.

**Why do our other blob workers, like the PCD loader, keep working under the same CSP?**

They are self-contained. The PCD loader inlines its entire parser into one worker string and never calls `importScripts`, so it only needs worker creation, which the CSP permits. troika is the only worker that fetches its code in a second `importScripts(blob:)` step, which is the step the CSP blocks. troika-worker-utils exposes no option to emit a self-contained worker, so `configureTextBuilder({ useWorker: false })` is the supported escape hatch.

**Why fork the Threlte component instead of passing `domElement` plus a CSS rule?**

Threlte's `PerfMonitor` does accept a `domElement` prop, but three-perf hardcodes `position: fixed` on its wrapper, so correcting the anchor still requires overriding that style. Doing it with a global CSS rule fails in the exact embedded case this PR targets: the standalone `app.css` does not ship with the packaged library (svelte-package builds from `src/lib`, which imports no CSS), and having a library leak a global `#three-perf-ui` rule into a host page is a worse smell than the self-contained JS override. The fork duplicates a small amount of stable stage-wiring, which is the accepted tradeoff.

### Testing

Ran `pnpm check` (svelte-check + go vet) and `pnpm lint` (prettier + eslint), both clean.

Verified behavior by driving the running app headless with Playwright against the snapshot scene, since the bug is only observable at runtime. Toggled Settings > Debug > Render stats and confirmed the monitor anchors to the container's top-right corner rather than the viewport, with all numeric counters rendering. Intercepted every `Worker` construction and confirmed none originate from troika (only the PCD, GLTF, and Sentry blob workers appear). With an entity selected, confirmed the monitor paints above the Details panel that shares its corner. No automated tests were added; this is a UI and debug-overlay behavior change verified by hand.
