### PR TITLE
Add motion plan JSON parser (parsePlan)

### DIFF
--- a/.changeset/motion-plan-replayer-1a-parse.md
+++ b/.changeset/motion-plan-replayer-1a-parse.md
@@ -1,0 +1,5 @@
+---
+'@viamrobotics/motion-tools': patch
+---
+
+Add the motion plan JSON parser (`parsePlan`) for the Motion Plan Replayer: validates and normalizes plan JSON into a `ParsedPlan` (frames, parents, trajectory, goals).

--- a/.prettierignore
+++ b/.prettierignore
@@ -19,5 +19,9 @@ draw/__snapshots__
 e2e/*.ts-snapshots
 static/test-fixtures
 
+# A captured motion plan is two JSON objects concatenated with no separator, so
+# it is not valid JSON and prettier cannot round-trip it.
+src/lib/plugins/MotionPlanReplayer/__tests__/__fixtures__/plan.json
+
 # IDE
 .cursor

--- a/src/lib/plugins/MotionPlanReplayer/__tests__/__fixtures__/plan.json
+++ b/src/lib/plugins/MotionPlanReplayer/__tests__/__fixtures__/plan.json
@@ -1,0 +1,6554 @@
+{
+    "frame_system": {
+        "name": "builtin",
+        "world": {
+            "frame_type": "static",
+            "frame": {
+                "id": "world",
+                "translation": {
+                    "X": 0,
+                    "Y": 0,
+                    "Z": 0
+                },
+                "orientation": {
+                    "type": "quaternion",
+                    "value": {
+                        "W": 1,
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    }
+                }
+            }
+        },
+        "frames": {
+            "cam-left-cup-crop": {
+                "frame_type": "static",
+                "frame": {
+                    "id": "cam-left-cup-crop",
+                    "translation": {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    "orientation": {
+                        "type": "quaternion",
+                        "value": {
+                            "W": 1,
+                            "X": 0,
+                            "Y": 0,
+                            "Z": 0
+                        }
+                    }
+                }
+            },
+            "cam-left-cup-crop_origin": {
+                "frame_type": "tail_geometry_static",
+                "frame": {
+                    "id": "cam-left-cup-crop_origin",
+                    "translation": {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    "orientation": {
+                        "type": "quaternion",
+                        "value": {
+                            "W": 1,
+                            "X": 0,
+                            "Y": 0,
+                            "Z": 0
+                        }
+                    }
+                }
+            },
+            "cam-merged-cup": {
+                "frame_type": "static",
+                "frame": {
+                    "id": "cam-merged-cup",
+                    "translation": {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    "orientation": {
+                        "type": "quaternion",
+                        "value": {
+                            "W": 1,
+                            "X": 0,
+                            "Y": 0,
+                            "Z": 0
+                        }
+                    }
+                }
+            },
+            "cam-merged-cup_origin": {
+                "frame_type": "tail_geometry_static",
+                "frame": {
+                    "id": "cam-merged-cup_origin",
+                    "translation": {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    "orientation": {
+                        "type": "quaternion",
+                        "value": {
+                            "W": 1,
+                            "X": 0,
+                            "Y": 0,
+                            "Z": 0
+                        }
+                    }
+                }
+            },
+            "left-arm": {
+                "frame_type": "model",
+                "frame": {
+                    "name": "left-arm",
+                    "model": {
+                        "name": "xArm6",
+                        "links": [
+                            {
+                                "id": "base",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": null,
+                                "geometry": {
+                                    "type": "",
+                                    "x": 0,
+                                    "y": 0,
+                                    "z": 0,
+                                    "r": 1,
+                                    "l": 0,
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": ""
+                                    },
+                                    "Label": ""
+                                },
+                                "parent": "world"
+                            },
+                            {
+                                "id": "base_top",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 267
+                                },
+                                "orientation": null,
+                                "geometry": {
+                                    "type": "",
+                                    "x": 0,
+                                    "y": 0,
+                                    "z": 0,
+                                    "r": 50,
+                                    "l": 320,
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 160
+                                    },
+                                    "orientation": {
+                                        "type": ""
+                                    },
+                                    "Label": ""
+                                },
+                                "parent": "waist"
+                            },
+                            {
+                                "id": "upper_arm",
+                                "translation": {
+                                    "X": 53.5,
+                                    "Y": 0,
+                                    "Z": 284.5
+                                },
+                                "orientation": null,
+                                "geometry": {
+                                    "type": "",
+                                    "x": 0,
+                                    "y": 0,
+                                    "z": 0,
+                                    "r": 70,
+                                    "l": 370,
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 40,
+                                        "Z": 135
+                                    },
+                                    "orientation": {
+                                        "type": "ov_degrees",
+                                        "value": {
+                                            "x": 0,
+                                            "y": -0.333,
+                                            "z": 0.666
+                                        }
+                                    },
+                                    "Label": ""
+                                },
+                                "parent": "shoulder"
+                            },
+                            {
+                                "id": "upper_forearm",
+                                "translation": {
+                                    "X": 77.5,
+                                    "Y": 0,
+                                    "Z": -172.5
+                                },
+                                "orientation": null,
+                                "geometry": {
+                                    "type": "",
+                                    "x": 80,
+                                    "y": 180,
+                                    "z": 250,
+                                    "r": 0,
+                                    "l": 0,
+                                    "translation": {
+                                        "X": 49.49,
+                                        "Y": 20,
+                                        "Z": -49.49
+                                    },
+                                    "orientation": {
+                                        "type": "ov_degrees",
+                                        "value": {
+                                            "th": 0,
+                                            "x": 0.707106,
+                                            "y": 0,
+                                            "z": -0.707106
+                                        }
+                                    },
+                                    "Label": ""
+                                },
+                                "parent": "elbow"
+                            },
+                            {
+                                "id": "lower_forearm",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": -170
+                                },
+                                "orientation": null,
+                                "geometry": {
+                                    "type": "",
+                                    "x": 0,
+                                    "y": 0,
+                                    "z": 0,
+                                    "r": 45,
+                                    "l": 285,
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": -27.5,
+                                        "Z": -104.8
+                                    },
+                                    "orientation": {
+                                        "type": "ov_degrees",
+                                        "value": {
+                                            "th": -90,
+                                            "x": 0,
+                                            "y": 0.2537568,
+                                            "z": 0.9672615
+                                        }
+                                    },
+                                    "Label": ""
+                                },
+                                "parent": "forearm_rot"
+                            },
+                            {
+                                "id": "wrist_link",
+                                "translation": {
+                                    "X": 76,
+                                    "Y": 0,
+                                    "Z": -97
+                                },
+                                "orientation": null,
+                                "geometry": {
+                                    "type": "",
+                                    "x": 150,
+                                    "y": 100,
+                                    "z": 125,
+                                    "r": 0,
+                                    "l": 0,
+                                    "translation": {
+                                        "X": 35,
+                                        "Y": 0,
+                                        "Z": -32.5
+                                    },
+                                    "orientation": {
+                                        "type": ""
+                                    },
+                                    "Label": ""
+                                },
+                                "parent": "wrist"
+                            },
+                            {
+                                "id": "gripper_mount",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "ov_degrees",
+                                    "value": {
+                                        "th": 0,
+                                        "x": 0,
+                                        "y": 0,
+                                        "z": -1
+                                    }
+                                },
+                                "geometry": {
+                                    "type": "",
+                                    "x": 0,
+                                    "y": 0,
+                                    "z": 0,
+                                    "r": 1,
+                                    "l": 0,
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": ""
+                                    },
+                                    "Label": ""
+                                },
+                                "parent": "gripper_rot"
+                            }
+                        ],
+                        "joints": [
+                            {
+                                "id": "waist",
+                                "type": "revolute",
+                                "parent": "base",
+                                "axis": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 1
+                                },
+                                "max": 359,
+                                "min": -359
+                            },
+                            {
+                                "id": "shoulder",
+                                "type": "revolute",
+                                "parent": "base_top",
+                                "axis": {
+                                    "X": 0,
+                                    "Y": 1,
+                                    "Z": 0
+                                },
+                                "max": 120,
+                                "min": -118
+                            },
+                            {
+                                "id": "elbow",
+                                "type": "revolute",
+                                "parent": "upper_arm",
+                                "axis": {
+                                    "X": 0,
+                                    "Y": 1,
+                                    "Z": 0
+                                },
+                                "max": 10,
+                                "min": -225
+                            },
+                            {
+                                "id": "forearm_rot",
+                                "type": "revolute",
+                                "parent": "upper_forearm",
+                                "axis": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": -1
+                                },
+                                "max": 359,
+                                "min": -359
+                            },
+                            {
+                                "id": "wrist",
+                                "type": "revolute",
+                                "parent": "lower_forearm",
+                                "axis": {
+                                    "X": 0,
+                                    "Y": 1,
+                                    "Z": 0
+                                },
+                                "max": 179,
+                                "min": -97
+                            },
+                            {
+                                "id": "gripper_rot",
+                                "type": "revolute",
+                                "parent": "wrist_link",
+                                "axis": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": -1
+                                },
+                                "max": 359,
+                                "min": -359
+                            }
+                        ],
+                        "original_file": {
+                            "bytes": "ewogICAgIm5hbWUiOiAieEFybTYiLAogICAgImxpbmtzIjogWwogICAgICAgIHsKICAgICAgICAgICAgImlkIjogImJhc2UiLAogICAgICAgICAgICAicGFyZW50IjogIndvcmxkIiwKICAgICAgICAgICAgInRyYW5zbGF0aW9uIjogewogICAgICAgICAgICAgICAgIngiOiAwLAogICAgICAgICAgICAgICAgInkiOiAwLAogICAgICAgICAgICAgICAgInoiOiAwCiAgICAgICAgICAgIH0sCiAgICAgICAgICAgICJnZW9tZXRyeSI6IHsKICAgICAgICAgICAgICAgICJyIjogMQogICAgICAgICAgICB9CiAgICAgICAgfSwKICAgICAgICB7CiAgICAgICAgICAgICJpZCI6ICJiYXNlX3RvcCIsCiAgICAgICAgICAgICJwYXJlbnQiOiAid2Fpc3QiLAogICAgICAgICAgICAidHJhbnNsYXRpb24iOiB7CiAgICAgICAgICAgICAgICAieCI6IDAsCiAgICAgICAgICAgICAgICAieSI6IDAsCiAgICAgICAgICAgICAgICAieiI6IDI2NwogICAgICAgICAgICB9LAogICAgICAgICAgICAiZ2VvbWV0cnkiOiB7CiAgICAgICAgICAgICAgICAiciI6IDUwLAogICAgICAgICAgICAgICAgImwiOiAzMjAsCiAgICAgICAgICAgICAgICAidHJhbnNsYXRpb24iOiB7CiAgICAgICAgICAgICAgICAgICAgIngiOiAwLAogICAgICAgICAgICAgICAgICAgICJ5IjogMCwKICAgICAgICAgICAgICAgICAgICAieiI6IDE2MAogICAgICAgICAgICAgICAgfQogICAgICAgICAgICB9CiAgICAgICAgfSwKICAgICAgICB7CiAgICAgICAgICAgICJpZCI6ICJ1cHBlcl9hcm0iLAogICAgICAgICAgICAicGFyZW50IjogInNob3VsZGVyIiwKICAgICAgICAgICAgInRyYW5zbGF0aW9uIjogewogICAgICAgICAgICAgICAgIngiOiA1My41LAogICAgICAgICAgICAgICAgInkiOiAwLAogICAgICAgICAgICAgICAgInoiOiAyODQuNQogICAgICAgICAgICB9LAogICAgICAgICAgICAiZ2VvbWV0cnkiOiB7CiAgICAgICAgICAgICAgICAiciI6IDcwLAogICAgICAgICAgICAgICAgImwiOiAzNzAsCiAgICAgICAgICAgICAgICAidHJhbnNsYXRpb24iOiB7CiAgICAgICAgICAgICAgICAgICAgIngiOiAwLAogICAgICAgICAgICAgICAgICAgICJ5IjogNDAsCiAgICAgICAgICAgICAgICAgICAgInoiOiAxMzUKICAgICAgICAgICAgICAgIH0sCiAgICAgICAgICAgICAgICAib3JpZW50YXRpb24iIDogewogICAgICAgICAgICAgICAgICAgICJ0eXBlIiA6ICJvdl9kZWdyZWVzIiwKICAgICAgICAgICAgICAgICAgICAidmFsdWUiIDogewogICAgICAgICAgICAgICAgICAgICAgICAieCIgOiAwLAogICAgICAgICAgICAgICAgICAgICAgICAieSIgOiAtMC4zMzMsCiAgICAgICAgICAgICAgICAgICAgICAgICJ6IiA6ICAwLjY2NgogICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgfQogICAgICAgIH0sCiAgICAgICAgewogICAgICAgICAgICAiaWQiOiAidXBwZXJfZm9yZWFybSIsCiAgICAgICAgICAgICJwYXJlbnQiOiAiZWxib3ciLAogICAgICAgICAgICAidHJhbnNsYXRpb24iOiB7CiAgICAgICAgICAgICAgICAieCI6IDc3LjUsCiAgICAgICAgICAgICAgICAieSI6IDAsCiAgICAgICAgICAgICAgICAieiI6IC0xNzIuNQogICAgICAgICAgICB9LAogICAgICAgICAgICAiZ2VvbWV0cnkiOiB7CiAgICAgICAgICAgICAgICAieCI6IDgwLAogICAgICAgICAgICAgICAgInkiOiAxODAsCiAgICAgICAgICAgICAgICAieiI6IDI1MCwKICAgICAgICAgICAgICAgICJ0cmFuc2xhdGlvbiI6IHsKICAgICAgICAgICAgICAgICAgICAieCI6IDQ5LjQ5LAogICAgICAgICAgICAgICAgICAgICJ5IjogMjAsCiAgICAgICAgICAgICAgICAgICAgInoiOiAtNDkuNDkKICAgICAgICAgICAgICAgIH0sCiAgICAgICAgICAgICAgICAib3JpZW50YXRpb24iOiB7CiAgICAgICAgICAgICAgICAgICAgInR5cGUiOiAib3ZfZGVncmVlcyIsCiAgICAgICAgICAgICAgICAgICAgInZhbHVlIjogewogICAgICAgICAgICAgICAgICAgICAgICAieCI6IDAuNzA3MTA2LAogICAgICAgICAgICAgICAgICAgICAgICAieSI6IDAsCiAgICAgICAgICAgICAgICAgICAgICAgICJ6IjogLTAuNzA3MTA2LAogICAgICAgICAgICAgICAgICAgICAgICAidGgiOiAwCiAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgfQogICAgICAgICAgICB9CiAgICAgICAgfSwKICAgICAgICB7CiAgICAgICAgICAgICJpZCI6ICJsb3dlcl9mb3JlYXJtIiwKICAgICAgICAgICAgInBhcmVudCI6ICJmb3JlYXJtX3JvdCIsCiAgICAgICAgICAgICJ0cmFuc2xhdGlvbiI6IHsKICAgICAgICAgICAgICAgICJ4IjogMCwKICAgICAgICAgICAgICAgICJ5IjogMCwKICAgICAgICAgICAgICAgICJ6IjogLTE3MAogICAgICAgICAgICB9LAogICAgICAgICAgICAiZ2VvbWV0cnkiOiB7CiAgICAgICAgICAgICAgICAiciI6IDQ1LAogICAgICAgICAgICAgICAgImwiOiAyODUsCiAgICAgICAgICAgICAgICAidHJhbnNsYXRpb24iOiB7CiAgICAgICAgICAgICAgICAgICAgIngiOiAwLAogICAgICAgICAgICAgICAgICAgICJ5IjogLTI3LjUsCiAgICAgICAgICAgICAgICAgICAgInoiOiAtMTA0LjgKICAgICAgICAgICAgICAgIH0sCiAgICAgICAgICAgICAgICAib3JpZW50YXRpb24iOiB7CiAgICAgICAgICAgICAgICAgICAgInR5cGUiOiAib3ZfZGVncmVlcyIsCiAgICAgICAgICAgICAgICAgICAgInZhbHVlIjogewogICAgICAgICAgICAgICAgICAgICAgICAidGgiOiAtOTAsCiAgICAgICAgICAgICAgICAgICAgICAgICJ4IjogMCwKICAgICAgICAgICAgICAgICAgICAgICAgInkiOiAwLjI1Mzc1NjgsCiAgICAgICAgICAgICAgICAgICAgICAgICJ6IjogMC45NjcyNjE1CiAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgfQogICAgICAgICAgICB9CiAgICAgICAgfSwKICAgICAgICB7CiAgICAgICAgICAgICJpZCI6ICJ3cmlzdF9saW5rIiwKICAgICAgICAgICAgInBhcmVudCI6ICJ3cmlzdCIsCiAgICAgICAgICAgICJ0cmFuc2xhdGlvbiI6IHsKICAgICAgICAgICAgICAgICJ4IjogNzYsCiAgICAgICAgICAgICAgICAieSI6IDAsCiAgICAgICAgICAgICAgICAieiI6IC05NwogICAgICAgICAgICB9LAogICAgICAgICAgICAiZ2VvbWV0cnkiOiB7CiAgICAgICAgICAgICAgICAieCI6IDE1MCwKICAgICAgICAgICAgICAgICJ5IjogMTAwLAogICAgICAgICAgICAgICAgInoiOiAxMjUsCiAgICAgICAgICAgICAgICAidHJhbnNsYXRpb24iOiB7CiAgICAgICAgICAgICAgICAgICAgIngiOiAzNSwKICAgICAgICAgICAgICAgICAgICAieSI6IDAsCiAgICAgICAgICAgICAgICAgICAgInoiOiAtMzIuNQogICAgICAgICAgICAgICAgfQogICAgICAgICAgICB9CiAgICAgICAgfSwKICAgICAgICB7CiAgICAgICAgICAgICJpZCI6ICJncmlwcGVyX21vdW50IiwKICAgICAgICAgICAgInBhcmVudCI6ICJncmlwcGVyX3JvdCIsCiAgICAgICAgICAgICJ0cmFuc2xhdGlvbiI6IHsKICAgICAgICAgICAgICAgICJ4IjogMCwKICAgICAgICAgICAgICAgICJ5IjogMCwKICAgICAgICAgICAgICAgICJ6IjogMAogICAgICAgICAgICB9LAogICAgICAgICAgICAib3JpZW50YXRpb24iOiB7CiAgICAgICAgICAgICAgICAidHlwZSI6ICJvdl9kZWdyZWVzIiwKICAgICAgICAgICAgICAgICJ2YWx1ZSI6IHsKICAgICAgICAgICAgICAgICAgICAieCI6IDAsCiAgICAgICAgICAgICAgICAgICAgInkiOiAwLAogICAgICAgICAgICAgICAgICAgICJ6IjogLTEsCiAgICAgICAgICAgICAgICAgICAgInRoIjogMAogICAgICAgICAgICAgICAgfQogICAgICAgICAgICB9LAogICAgICAgICAgICAiZ2VvbWV0cnkiOiB7CiAgICAgICAgICAgICAgICAiciI6IDEKICAgICAgICAgICAgfQogICAgICAgIH0KICAgIF0sCiAgICAiam9pbnRzIjogWwogICAgICAgIHsKICAgICAgICAgICAgImlkIjogIndhaXN0IiwKICAgICAgICAgICAgInR5cGUiOiAicmV2b2x1dGUiLAogICAgICAgICAgICAicGFyZW50IjogImJhc2UiLAogICAgICAgICAgICAiYXhpcyI6IHsKICAgICAgICAgICAgICAgICJ4IjogMCwKICAgICAgICAgICAgICAgICJ5IjogMCwKICAgICAgICAgICAgICAgICJ6IjogMQogICAgICAgICAgICB9LAogICAgICAgICAgICAibWF4IjogMzU5LAogICAgICAgICAgICAibWluIjogLTM1OQogICAgICAgIH0sCiAgICAgICAgewogICAgICAgICAgICAiaWQiOiAic2hvdWxkZXIiLAogICAgICAgICAgICAidHlwZSI6ICJyZXZvbHV0ZSIsCiAgICAgICAgICAgICJwYXJlbnQiOiAiYmFzZV90b3AiLAogICAgICAgICAgICAiYXhpcyI6IHsKICAgICAgICAgICAgICAgICJ4IjogMCwKICAgICAgICAgICAgICAgICJ5IjogMSwKICAgICAgICAgICAgICAgICJ6IjogMAogICAgICAgICAgICB9LAogICAgICAgICAgICAibWF4IjogMTIwLAogICAgICAgICAgICAibWluIjogLTExOAogICAgICAgIH0sCiAgICAgICAgewogICAgICAgICAgICAiaWQiOiAiZWxib3ciLAogICAgICAgICAgICAidHlwZSI6ICJyZXZvbHV0ZSIsCiAgICAgICAgICAgICJwYXJlbnQiOiAidXBwZXJfYXJtIiwKICAgICAgICAgICAgImF4aXMiOiB7CiAgICAgICAgICAgICAgICAieCI6IDAsCiAgICAgICAgICAgICAgICAieSI6IDEsCiAgICAgICAgICAgICAgICAieiI6IDAKICAgICAgICAgICAgfSwKICAgICAgICAgICAgIm1heCI6IDEwLAogICAgICAgICAgICAibWluIjogLTIyNQogICAgICAgIH0sCiAgICAgICAgewogICAgICAgICAgICAiaWQiOiAiZm9yZWFybV9yb3QiLAogICAgICAgICAgICAidHlwZSI6ICJyZXZvbHV0ZSIsCiAgICAgICAgICAgICJwYXJlbnQiOiAidXBwZXJfZm9yZWFybSIsCiAgICAgICAgICAgICJheGlzIjogewogICAgICAgICAgICAgICAgIngiOiAwLAogICAgICAgICAgICAgICAgInkiOiAwLAogICAgICAgICAgICAgICAgInoiOiAtMQogICAgICAgICAgICB9LAogICAgICAgICAgICAibWF4IjogMzU5LAogICAgICAgICAgICAibWluIjogLTM1OQogICAgICAgIH0sCiAgICAgICAgewogICAgICAgICAgICAiaWQiOiAid3Jpc3QiLAogICAgICAgICAgICAidHlwZSI6ICJyZXZvbHV0ZSIsCiAgICAgICAgICAgICJwYXJlbnQiOiAibG93ZXJfZm9yZWFybSIsCiAgICAgICAgICAgICJheGlzIjogewogICAgICAgICAgICAgICAgIngiOiAwLAogICAgICAgICAgICAgICAgInkiOiAxLAogICAgICAgICAgICAgICAgInoiOiAwCiAgICAgICAgICAgIH0sCiAgICAgICAgICAgICJtYXgiOiAxNzksCiAgICAgICAgICAgICJtaW4iOiAtOTcKICAgICAgICB9LAogICAgICAgIHsKICAgICAgICAgICAgImlkIjogImdyaXBwZXJfcm90IiwKICAgICAgICAgICAgInR5cGUiOiAicmV2b2x1dGUiLAogICAgICAgICAgICAicGFyZW50IjogIndyaXN0X2xpbmsiLAogICAgICAgICAgICAiYXhpcyI6IHsKICAgICAgICAgICAgICAgICJ4IjogMCwKICAgICAgICAgICAgICAgICJ5IjogMCwKICAgICAgICAgICAgICAgICJ6IjogLTEKICAgICAgICAgICAgfSwKICAgICAgICAgICAgIm1heCI6IDM1OSwKICAgICAgICAgICAgIm1pbiI6IC0zNTkKICAgICAgICB9CiAgICBdCn0K",
+                            "extension": "json"
+                        }
+                    },
+                    "limits": [
+                        {
+                            "Min": -6.265732014659642,
+                            "Max": 6.265732014659642
+                        },
+                        {
+                            "Min": -2.0594885173533086,
+                            "Max": 2.0943951023931953
+                        },
+                        {
+                            "Min": -3.9269908169872414,
+                            "Max": 0.17453292519943295
+                        },
+                        {
+                            "Min": -6.265732014659642,
+                            "Max": 6.265732014659642
+                        },
+                        {
+                            "Min": -1.6929693744344996,
+                            "Max": 3.12413936106985
+                        },
+                        {
+                            "Min": -6.265732014659642,
+                            "Max": 6.265732014659642
+                        }
+                    ],
+                    "internal_fs": {
+                        "name": "internal",
+                        "world": {
+                            "frame_type": "static",
+                            "frame": {
+                                "id": "world",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                }
+                            }
+                        },
+                        "frames": {
+                            "base": {
+                                "frame_type": "static",
+                                "frame": {
+                                    "id": "base",
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "geometry": {
+                                        "type": "sphere",
+                                        "x": 0,
+                                        "y": 0,
+                                        "z": 0,
+                                        "r": 1,
+                                        "l": 0,
+                                        "translation": {
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        },
+                                        "orientation": {
+                                            "type": "quaternion",
+                                            "value": {
+                                                "W": 1,
+                                                "X": 0,
+                                                "Y": 0,
+                                                "Z": 0
+                                            }
+                                        },
+                                        "Label": "base"
+                                    }
+                                }
+                            },
+                            "base_top": {
+                                "frame_type": "static",
+                                "frame": {
+                                    "id": "base_top",
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 267
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "geometry": {
+                                        "type": "capsule",
+                                        "x": 0,
+                                        "y": 0,
+                                        "z": 0,
+                                        "r": 50,
+                                        "l": 320,
+                                        "translation": {
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 160
+                                        },
+                                        "orientation": {
+                                            "type": "quaternion",
+                                            "value": {
+                                                "W": 1,
+                                                "X": 0,
+                                                "Y": 0,
+                                                "Z": 0
+                                            }
+                                        },
+                                        "Label": "base_top"
+                                    }
+                                }
+                            },
+                            "elbow": {
+                                "frame_type": "rotational",
+                                "frame": {
+                                    "id": "elbow",
+                                    "type": "revolute",
+                                    "parent": "",
+                                    "axis": {
+                                        "X": 0,
+                                        "Y": 1,
+                                        "Z": 0
+                                    },
+                                    "max": 10,
+                                    "min": -225
+                                }
+                            },
+                            "forearm_rot": {
+                                "frame_type": "rotational",
+                                "frame": {
+                                    "id": "forearm_rot",
+                                    "type": "revolute",
+                                    "parent": "",
+                                    "axis": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": -1
+                                    },
+                                    "max": 359,
+                                    "min": -359
+                                }
+                            },
+                            "gripper_mount": {
+                                "frame_type": "static",
+                                "frame": {
+                                    "id": "gripper_mount",
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 6.123233995736757e-17,
+                                            "X": 0,
+                                            "Y": 1,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "geometry": {
+                                        "type": "sphere",
+                                        "x": 0,
+                                        "y": 0,
+                                        "z": 0,
+                                        "r": 1,
+                                        "l": 0,
+                                        "translation": {
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        },
+                                        "orientation": {
+                                            "type": "quaternion",
+                                            "value": {
+                                                "W": 1,
+                                                "X": 0,
+                                                "Y": 0,
+                                                "Z": 0
+                                            }
+                                        },
+                                        "Label": "gripper_mount"
+                                    }
+                                }
+                            },
+                            "gripper_rot": {
+                                "frame_type": "rotational",
+                                "frame": {
+                                    "id": "gripper_rot",
+                                    "type": "revolute",
+                                    "parent": "",
+                                    "axis": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": -1
+                                    },
+                                    "max": 359,
+                                    "min": -359
+                                }
+                            },
+                            "lower_forearm": {
+                                "frame_type": "static",
+                                "frame": {
+                                    "id": "lower_forearm",
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": -170
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "geometry": {
+                                        "type": "capsule",
+                                        "x": 0,
+                                        "y": 0,
+                                        "z": 0,
+                                        "r": 45,
+                                        "l": 285,
+                                        "translation": {
+                                            "X": 1.4791141972893971e-31,
+                                            "Y": -27.499999999999993,
+                                            "Z": -104.79999999999995
+                                        },
+                                        "orientation": {
+                                            "type": "quaternion",
+                                            "value": {
+                                                "W": 0.9917831494535221,
+                                                "X": -0.12793038911866228,
+                                                "Y": 1.3877787807814457e-17,
+                                                "Z": -5.551115123125783e-17
+                                            }
+                                        },
+                                        "Label": "lower_forearm"
+                                    }
+                                }
+                            },
+                            "shoulder": {
+                                "frame_type": "rotational",
+                                "frame": {
+                                    "id": "shoulder",
+                                    "type": "revolute",
+                                    "parent": "",
+                                    "axis": {
+                                        "X": 0,
+                                        "Y": 1,
+                                        "Z": 0
+                                    },
+                                    "max": 119.99999999999999,
+                                    "min": -118
+                                }
+                            },
+                            "upper_arm": {
+                                "frame_type": "static",
+                                "frame": {
+                                    "id": "upper_arm",
+                                    "translation": {
+                                        "X": 53.5,
+                                        "Y": 0,
+                                        "Z": 284.5
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "geometry": {
+                                        "type": "capsule",
+                                        "x": 0,
+                                        "y": 0,
+                                        "z": 0,
+                                        "r": 70,
+                                        "l": 370,
+                                        "translation": {
+                                            "X": -5.329070518200751e-15,
+                                            "Y": 39.99999999999999,
+                                            "Z": 135
+                                        },
+                                        "orientation": {
+                                            "type": "quaternion",
+                                            "value": {
+                                                "W": 0.6881909602355868,
+                                                "X": 0.1624598481164531,
+                                                "Y": 0.16245984811645311,
+                                                "Z": -0.6881909602355867
+                                            }
+                                        },
+                                        "Label": "upper_arm"
+                                    }
+                                }
+                            },
+                            "upper_forearm": {
+                                "frame_type": "static",
+                                "frame": {
+                                    "id": "upper_forearm",
+                                    "translation": {
+                                        "X": 77.5,
+                                        "Y": 0,
+                                        "Z": -172.5
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "geometry": {
+                                        "type": "box",
+                                        "x": 80,
+                                        "y": 180,
+                                        "z": 250,
+                                        "r": 0,
+                                        "l": 0,
+                                        "translation": {
+                                            "X": 49.49,
+                                            "Y": 20,
+                                            "Z": -49.49
+                                        },
+                                        "orientation": {
+                                            "type": "quaternion",
+                                            "value": {
+                                                "W": 0.38268343236508984,
+                                                "X": 0,
+                                                "Y": 0.9238795325112867,
+                                                "Z": 0
+                                            }
+                                        },
+                                        "Label": "upper_forearm"
+                                    }
+                                }
+                            },
+                            "waist": {
+                                "frame_type": "rotational",
+                                "frame": {
+                                    "id": "waist",
+                                    "type": "revolute",
+                                    "parent": "",
+                                    "axis": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 1
+                                    },
+                                    "max": 359,
+                                    "min": -359
+                                }
+                            },
+                            "wrist": {
+                                "frame_type": "rotational",
+                                "frame": {
+                                    "id": "wrist",
+                                    "type": "revolute",
+                                    "parent": "",
+                                    "axis": {
+                                        "X": 0,
+                                        "Y": 1,
+                                        "Z": 0
+                                    },
+                                    "max": 179,
+                                    "min": -97
+                                }
+                            },
+                            "wrist_link": {
+                                "frame_type": "static",
+                                "frame": {
+                                    "id": "wrist_link",
+                                    "translation": {
+                                        "X": 76,
+                                        "Y": 0,
+                                        "Z": -97
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "geometry": {
+                                        "type": "box",
+                                        "x": 150,
+                                        "y": 100,
+                                        "z": 125,
+                                        "r": 0,
+                                        "l": 0,
+                                        "translation": {
+                                            "X": 35,
+                                            "Y": 0,
+                                            "Z": -32.5
+                                        },
+                                        "orientation": {
+                                            "type": "quaternion",
+                                            "value": {
+                                                "W": 1,
+                                                "X": 0,
+                                                "Y": 0,
+                                                "Z": 0
+                                            }
+                                        },
+                                        "Label": "wrist_link"
+                                    }
+                                }
+                            }
+                        },
+                        "parents": {
+                            "base": "world",
+                            "base_top": "waist",
+                            "elbow": "upper_arm",
+                            "forearm_rot": "upper_forearm",
+                            "gripper_mount": "gripper_rot",
+                            "gripper_rot": "wrist_link",
+                            "lower_forearm": "forearm_rot",
+                            "shoulder": "base_top",
+                            "upper_arm": "shoulder",
+                            "upper_forearm": "elbow",
+                            "waist": "base",
+                            "wrist": "lower_forearm",
+                            "wrist_link": "wrist"
+                        }
+                    },
+                    "primary_output_frame": "gripper_mount"
+                }
+            },
+            "left-arm:base": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "left-arm:base",
+                    "inner_frame": {
+                        "frame_type": "static",
+                        "frame": {
+                            "id": "base",
+                            "translation": {
+                                "X": 0,
+                                "Y": 0,
+                                "Z": 0
+                            },
+                            "orientation": {
+                                "type": "quaternion",
+                                "value": {
+                                    "W": 1,
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                }
+                            },
+                            "geometry": {
+                                "type": "sphere",
+                                "x": 0,
+                                "y": 0,
+                                "z": 0,
+                                "r": 1,
+                                "l": 0,
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "Label": "base"
+                            }
+                        }
+                    }
+                }
+            },
+            "left-arm:base_top": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "left-arm:base_top",
+                    "inner_frame": {
+                        "frame_type": "static",
+                        "frame": {
+                            "id": "base_top",
+                            "translation": {
+                                "X": 0,
+                                "Y": 0,
+                                "Z": 267
+                            },
+                            "orientation": {
+                                "type": "quaternion",
+                                "value": {
+                                    "W": 1,
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                }
+                            },
+                            "geometry": {
+                                "type": "capsule",
+                                "x": 0,
+                                "y": 0,
+                                "z": 0,
+                                "r": 50,
+                                "l": 320,
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 160
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "Label": "base_top"
+                            }
+                        }
+                    }
+                }
+            },
+            "left-arm:elbow": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "left-arm:elbow",
+                    "inner_frame": {
+                        "frame_type": "rotational",
+                        "frame": {
+                            "id": "elbow",
+                            "type": "revolute",
+                            "parent": "",
+                            "axis": {
+                                "X": 0,
+                                "Y": 1,
+                                "Z": 0
+                            },
+                            "max": 10,
+                            "min": -225
+                        }
+                    }
+                }
+            },
+            "left-arm:forearm_rot": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "left-arm:forearm_rot",
+                    "inner_frame": {
+                        "frame_type": "rotational",
+                        "frame": {
+                            "id": "forearm_rot",
+                            "type": "revolute",
+                            "parent": "",
+                            "axis": {
+                                "X": 0,
+                                "Y": 0,
+                                "Z": -1
+                            },
+                            "max": 359,
+                            "min": -359
+                        }
+                    }
+                }
+            },
+            "left-arm:gripper_mount": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "left-arm:gripper_mount",
+                    "inner_frame": {
+                        "frame_type": "static",
+                        "frame": {
+                            "id": "gripper_mount",
+                            "translation": {
+                                "X": 0,
+                                "Y": 0,
+                                "Z": 0
+                            },
+                            "orientation": {
+                                "type": "quaternion",
+                                "value": {
+                                    "W": 6.123233995736757e-17,
+                                    "X": 0,
+                                    "Y": 1,
+                                    "Z": 0
+                                }
+                            },
+                            "geometry": {
+                                "type": "sphere",
+                                "x": 0,
+                                "y": 0,
+                                "z": 0,
+                                "r": 1,
+                                "l": 0,
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "Label": "gripper_mount"
+                            }
+                        }
+                    }
+                }
+            },
+            "left-arm:gripper_rot": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "left-arm:gripper_rot",
+                    "inner_frame": {
+                        "frame_type": "rotational",
+                        "frame": {
+                            "id": "gripper_rot",
+                            "type": "revolute",
+                            "parent": "",
+                            "axis": {
+                                "X": 0,
+                                "Y": 0,
+                                "Z": -1
+                            },
+                            "max": 359,
+                            "min": -359
+                        }
+                    }
+                }
+            },
+            "left-arm:lower_forearm": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "left-arm:lower_forearm",
+                    "inner_frame": {
+                        "frame_type": "static",
+                        "frame": {
+                            "id": "lower_forearm",
+                            "translation": {
+                                "X": 0,
+                                "Y": 0,
+                                "Z": -170
+                            },
+                            "orientation": {
+                                "type": "quaternion",
+                                "value": {
+                                    "W": 1,
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                }
+                            },
+                            "geometry": {
+                                "type": "capsule",
+                                "x": 0,
+                                "y": 0,
+                                "z": 0,
+                                "r": 45,
+                                "l": 285,
+                                "translation": {
+                                    "X": 1.4791141972893971e-31,
+                                    "Y": -27.499999999999993,
+                                    "Z": -104.79999999999995
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 0.9917831494535221,
+                                        "X": -0.12793038911866228,
+                                        "Y": 1.3877787807814457e-17,
+                                        "Z": -5.551115123125783e-17
+                                    }
+                                },
+                                "Label": "lower_forearm"
+                            }
+                        }
+                    }
+                }
+            },
+            "left-arm:shoulder": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "left-arm:shoulder",
+                    "inner_frame": {
+                        "frame_type": "rotational",
+                        "frame": {
+                            "id": "shoulder",
+                            "type": "revolute",
+                            "parent": "",
+                            "axis": {
+                                "X": 0,
+                                "Y": 1,
+                                "Z": 0
+                            },
+                            "max": 119.99999999999999,
+                            "min": -118
+                        }
+                    }
+                }
+            },
+            "left-arm:upper_arm": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "left-arm:upper_arm",
+                    "inner_frame": {
+                        "frame_type": "static",
+                        "frame": {
+                            "id": "upper_arm",
+                            "translation": {
+                                "X": 53.5,
+                                "Y": 0,
+                                "Z": 284.5
+                            },
+                            "orientation": {
+                                "type": "quaternion",
+                                "value": {
+                                    "W": 1,
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                }
+                            },
+                            "geometry": {
+                                "type": "capsule",
+                                "x": 0,
+                                "y": 0,
+                                "z": 0,
+                                "r": 70,
+                                "l": 370,
+                                "translation": {
+                                    "X": -5.329070518200751e-15,
+                                    "Y": 39.99999999999999,
+                                    "Z": 135
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 0.6881909602355868,
+                                        "X": 0.1624598481164531,
+                                        "Y": 0.16245984811645311,
+                                        "Z": -0.6881909602355867
+                                    }
+                                },
+                                "Label": "upper_arm"
+                            }
+                        }
+                    }
+                }
+            },
+            "left-arm:upper_forearm": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "left-arm:upper_forearm",
+                    "inner_frame": {
+                        "frame_type": "static",
+                        "frame": {
+                            "id": "upper_forearm",
+                            "translation": {
+                                "X": 77.5,
+                                "Y": 0,
+                                "Z": -172.5
+                            },
+                            "orientation": {
+                                "type": "quaternion",
+                                "value": {
+                                    "W": 1,
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                }
+                            },
+                            "geometry": {
+                                "type": "box",
+                                "x": 80,
+                                "y": 180,
+                                "z": 250,
+                                "r": 0,
+                                "l": 0,
+                                "translation": {
+                                    "X": 49.49,
+                                    "Y": 20,
+                                    "Z": -49.49
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 0.38268343236508984,
+                                        "X": 0,
+                                        "Y": 0.9238795325112867,
+                                        "Z": 0
+                                    }
+                                },
+                                "Label": "upper_forearm"
+                            }
+                        }
+                    }
+                }
+            },
+            "left-arm:waist": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "left-arm:waist",
+                    "inner_frame": {
+                        "frame_type": "rotational",
+                        "frame": {
+                            "id": "waist",
+                            "type": "revolute",
+                            "parent": "",
+                            "axis": {
+                                "X": 0,
+                                "Y": 0,
+                                "Z": 1
+                            },
+                            "max": 359,
+                            "min": -359
+                        }
+                    }
+                }
+            },
+            "left-arm:wrist": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "left-arm:wrist",
+                    "inner_frame": {
+                        "frame_type": "rotational",
+                        "frame": {
+                            "id": "wrist",
+                            "type": "revolute",
+                            "parent": "",
+                            "axis": {
+                                "X": 0,
+                                "Y": 1,
+                                "Z": 0
+                            },
+                            "max": 179,
+                            "min": -97
+                        }
+                    }
+                }
+            },
+            "left-arm:wrist_link": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "left-arm:wrist_link",
+                    "inner_frame": {
+                        "frame_type": "static",
+                        "frame": {
+                            "id": "wrist_link",
+                            "translation": {
+                                "X": 76,
+                                "Y": 0,
+                                "Z": -97
+                            },
+                            "orientation": {
+                                "type": "quaternion",
+                                "value": {
+                                    "W": 1,
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                }
+                            },
+                            "geometry": {
+                                "type": "box",
+                                "x": 150,
+                                "y": 100,
+                                "z": 125,
+                                "r": 0,
+                                "l": 0,
+                                "translation": {
+                                    "X": 35,
+                                    "Y": 0,
+                                    "Z": -32.5
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "Label": "wrist_link"
+                            }
+                        }
+                    }
+                }
+            },
+            "left-arm_origin": {
+                "frame_type": "tail_geometry_static",
+                "frame": {
+                    "id": "left-arm_origin",
+                    "translation": {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    "orientation": {
+                        "type": "quaternion",
+                        "value": {
+                            "W": 0.9659258262890683,
+                            "X": -0,
+                            "Y": 0,
+                            "Z": -0.25881904510252074
+                        }
+                    }
+                }
+            },
+            "left-cam": {
+                "frame_type": "static",
+                "frame": {
+                    "id": "left-cam",
+                    "translation": {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    "orientation": {
+                        "type": "quaternion",
+                        "value": {
+                            "W": 1,
+                            "X": 0,
+                            "Y": 0,
+                            "Z": 0
+                        }
+                    }
+                }
+            },
+            "left-cam_origin": {
+                "frame_type": "tail_geometry_static",
+                "frame": {
+                    "id": "left-cam_origin",
+                    "translation": {
+                        "X": 80,
+                        "Y": -34.999999999999986,
+                        "Z": 35
+                    },
+                    "orientation": {
+                        "type": "quaternion",
+                        "value": {
+                            "W": -0.7137227636428367,
+                            "X": 0.009380437494157626,
+                            "Y": 0.012086963587744436,
+                            "Z": -0.7002611865309102
+                        }
+                    },
+                    "geometry": {
+                        "type": "box",
+                        "x": 90,
+                        "y": 25,
+                        "z": 25,
+                        "r": 0,
+                        "l": 0,
+                        "translation": {
+                            "X": 32.2,
+                            "Y": 0,
+                            "Z": -8.3
+                        },
+                        "orientation": {
+                            "type": "quaternion",
+                            "value": {
+                                "W": 1,
+                                "X": 0,
+                                "Y": 0,
+                                "Z": 0
+                            }
+                        },
+                        "Label": "left-cam_origin"
+                    }
+                }
+            },
+            "left-gripper": {
+                "frame_type": "model",
+                "frame": {
+                    "name": "left-gripper",
+                    "model": {
+                        "name": "left-gripper",
+                        "links": [
+                            {
+                                "id": "case-gripper",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "geometry": {
+                                    "type": "box",
+                                    "x": 50,
+                                    "y": 100,
+                                    "z": 100,
+                                    "r": 0,
+                                    "l": 0,
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": -50
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "Label": "case-gripper"
+                                },
+                                "parent": "world"
+                            },
+                            {
+                                "id": "claws",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "geometry": {
+                                    "type": "box",
+                                    "x": 40,
+                                    "y": 170,
+                                    "z": 105,
+                                    "r": 0,
+                                    "l": 0,
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": -2.5
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "Label": "claws"
+                                },
+                                "parent": "case-gripper"
+                            }
+                        ]
+                    },
+                    "limits": [],
+                    "internal_fs": {
+                        "name": "internal",
+                        "world": {
+                            "frame_type": "static",
+                            "frame": {
+                                "id": "world",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                }
+                            }
+                        },
+                        "frames": {
+                            "case-gripper": {
+                                "frame_type": "static",
+                                "frame": {
+                                    "id": "case-gripper",
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "geometry": {
+                                        "type": "box",
+                                        "x": 50,
+                                        "y": 100,
+                                        "z": 100,
+                                        "r": 0,
+                                        "l": 0,
+                                        "translation": {
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": -50
+                                        },
+                                        "orientation": {
+                                            "type": "quaternion",
+                                            "value": {
+                                                "W": 1,
+                                                "X": 0,
+                                                "Y": 0,
+                                                "Z": 0
+                                            }
+                                        },
+                                        "Label": "case-gripper"
+                                    }
+                                }
+                            },
+                            "claws": {
+                                "frame_type": "static",
+                                "frame": {
+                                    "id": "claws",
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "geometry": {
+                                        "type": "box",
+                                        "x": 40,
+                                        "y": 170,
+                                        "z": 105,
+                                        "r": 0,
+                                        "l": 0,
+                                        "translation": {
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": -2.5
+                                        },
+                                        "orientation": {
+                                            "type": "quaternion",
+                                            "value": {
+                                                "W": 1,
+                                                "X": 0,
+                                                "Y": 0,
+                                                "Z": 0
+                                            }
+                                        },
+                                        "Label": "claws"
+                                    }
+                                }
+                            }
+                        },
+                        "parents": {
+                            "case-gripper": "world",
+                            "claws": "case-gripper"
+                        }
+                    },
+                    "primary_output_frame": "claws"
+                }
+            },
+            "left-gripper:case-gripper": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "left-gripper:case-gripper",
+                    "inner_frame": {
+                        "frame_type": "static",
+                        "frame": {
+                            "id": "case-gripper",
+                            "translation": {
+                                "X": 0,
+                                "Y": 0,
+                                "Z": 0
+                            },
+                            "orientation": {
+                                "type": "quaternion",
+                                "value": {
+                                    "W": 1,
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                }
+                            },
+                            "geometry": {
+                                "type": "box",
+                                "x": 50,
+                                "y": 100,
+                                "z": 100,
+                                "r": 0,
+                                "l": 0,
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": -50
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "Label": "case-gripper"
+                            }
+                        }
+                    }
+                }
+            },
+            "left-gripper:claws": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "left-gripper:claws",
+                    "inner_frame": {
+                        "frame_type": "static",
+                        "frame": {
+                            "id": "claws",
+                            "translation": {
+                                "X": 0,
+                                "Y": 0,
+                                "Z": 0
+                            },
+                            "orientation": {
+                                "type": "quaternion",
+                                "value": {
+                                    "W": 1,
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                }
+                            },
+                            "geometry": {
+                                "type": "box",
+                                "x": 40,
+                                "y": 170,
+                                "z": 105,
+                                "r": 0,
+                                "l": 0,
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": -2.5
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "Label": "claws"
+                            }
+                        }
+                    }
+                }
+            },
+            "left-gripper_origin": {
+                "frame_type": "tail_geometry_static",
+                "frame": {
+                    "id": "left-gripper_origin",
+                    "translation": {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 150
+                    },
+                    "orientation": {
+                        "type": "quaternion",
+                        "value": {
+                            "W": 1,
+                            "X": 0,
+                            "Y": 0,
+                            "Z": 0
+                        }
+                    }
+                }
+            },
+            "obstacle-arm-left-cord": {
+                "frame_type": "model",
+                "frame": {
+                    "name": "obstacle-arm-left-cord",
+                    "model": {
+                        "name": "obstacle-arm-left-cord",
+                        "links": [
+                            {
+                                "id": "arm-left-cord",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "geometry": {
+                                    "type": "box",
+                                    "x": 50,
+                                    "y": 70,
+                                    "z": 50,
+                                    "r": 0,
+                                    "l": 0,
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "Label": "arm-left-cord"
+                                },
+                                "parent": "world"
+                            }
+                        ]
+                    },
+                    "limits": [],
+                    "internal_fs": {
+                        "name": "internal",
+                        "world": {
+                            "frame_type": "static",
+                            "frame": {
+                                "id": "world",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                }
+                            }
+                        },
+                        "frames": {
+                            "arm-left-cord": {
+                                "frame_type": "static",
+                                "frame": {
+                                    "id": "arm-left-cord",
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "geometry": {
+                                        "type": "box",
+                                        "x": 50,
+                                        "y": 70,
+                                        "z": 50,
+                                        "r": 0,
+                                        "l": 0,
+                                        "translation": {
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        },
+                                        "orientation": {
+                                            "type": "quaternion",
+                                            "value": {
+                                                "W": 1,
+                                                "X": 0,
+                                                "Y": 0,
+                                                "Z": 0
+                                            }
+                                        },
+                                        "Label": "arm-left-cord"
+                                    }
+                                }
+                            }
+                        },
+                        "parents": {
+                            "arm-left-cord": "world"
+                        }
+                    },
+                    "primary_output_frame": "arm-left-cord"
+                }
+            },
+            "obstacle-arm-left-cord:arm-left-cord": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "obstacle-arm-left-cord:arm-left-cord",
+                    "inner_frame": {
+                        "frame_type": "static",
+                        "frame": {
+                            "id": "arm-left-cord",
+                            "translation": {
+                                "X": 0,
+                                "Y": 0,
+                                "Z": 0
+                            },
+                            "orientation": {
+                                "type": "quaternion",
+                                "value": {
+                                    "W": 1,
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                }
+                            },
+                            "geometry": {
+                                "type": "box",
+                                "x": 50,
+                                "y": 70,
+                                "z": 50,
+                                "r": 0,
+                                "l": 0,
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "Label": "arm-left-cord"
+                            }
+                        }
+                    }
+                }
+            },
+            "obstacle-arm-left-cord_origin": {
+                "frame_type": "tail_geometry_static",
+                "frame": {
+                    "id": "obstacle-arm-left-cord_origin",
+                    "translation": {
+                        "X": 0,
+                        "Y": 80,
+                        "Z": -10
+                    },
+                    "orientation": {
+                        "type": "quaternion",
+                        "value": {
+                            "W": 1,
+                            "X": 0,
+                            "Y": 0,
+                            "Z": 0
+                        }
+                    }
+                }
+            },
+            "obstacle-back-wall": {
+                "frame_type": "model",
+                "frame": {
+                    "name": "obstacle-back-wall",
+                    "model": {
+                        "name": "obstacle-back-wall",
+                        "links": [
+                            {
+                                "id": "back-wall",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "geometry": {
+                                    "type": "box",
+                                    "x": 40,
+                                    "y": 1045,
+                                    "z": 80,
+                                    "r": 0,
+                                    "l": 0,
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "Label": "back-wall"
+                                },
+                                "parent": "world"
+                            }
+                        ]
+                    },
+                    "limits": [],
+                    "internal_fs": {
+                        "name": "internal",
+                        "world": {
+                            "frame_type": "static",
+                            "frame": {
+                                "id": "world",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                }
+                            }
+                        },
+                        "frames": {
+                            "back-wall": {
+                                "frame_type": "static",
+                                "frame": {
+                                    "id": "back-wall",
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "geometry": {
+                                        "type": "box",
+                                        "x": 40,
+                                        "y": 1045,
+                                        "z": 80,
+                                        "r": 0,
+                                        "l": 0,
+                                        "translation": {
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        },
+                                        "orientation": {
+                                            "type": "quaternion",
+                                            "value": {
+                                                "W": 1,
+                                                "X": 0,
+                                                "Y": 0,
+                                                "Z": 0
+                                            }
+                                        },
+                                        "Label": "back-wall"
+                                    }
+                                }
+                            }
+                        },
+                        "parents": {
+                            "back-wall": "world"
+                        }
+                    },
+                    "primary_output_frame": "back-wall"
+                }
+            },
+            "obstacle-back-wall:back-wall": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "obstacle-back-wall:back-wall",
+                    "inner_frame": {
+                        "frame_type": "static",
+                        "frame": {
+                            "id": "back-wall",
+                            "translation": {
+                                "X": 0,
+                                "Y": 0,
+                                "Z": 0
+                            },
+                            "orientation": {
+                                "type": "quaternion",
+                                "value": {
+                                    "W": 1,
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                }
+                            },
+                            "geometry": {
+                                "type": "box",
+                                "x": 40,
+                                "y": 1045,
+                                "z": 80,
+                                "r": 0,
+                                "l": 0,
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "Label": "back-wall"
+                            }
+                        }
+                    }
+                }
+            },
+            "obstacle-back-wall_origin": {
+                "frame_type": "tail_geometry_static",
+                "frame": {
+                    "id": "obstacle-back-wall_origin",
+                    "translation": {
+                        "X": -180,
+                        "Y": 412,
+                        "Z": 40
+                    },
+                    "orientation": {
+                        "type": "quaternion",
+                        "value": {
+                            "W": 1,
+                            "X": 0,
+                            "Y": 0,
+                            "Z": 0
+                        }
+                    }
+                }
+            },
+            "obstacle-ceiling": {
+                "frame_type": "model",
+                "frame": {
+                    "name": "obstacle-ceiling",
+                    "model": {
+                        "name": "obstacle-ceiling",
+                        "links": [
+                            {
+                                "id": "ceiling",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "geometry": {
+                                    "type": "box",
+                                    "x": 1500,
+                                    "y": 1500,
+                                    "z": 10,
+                                    "r": 0,
+                                    "l": 0,
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "Label": "ceiling"
+                                },
+                                "parent": "world"
+                            }
+                        ]
+                    },
+                    "limits": [],
+                    "internal_fs": {
+                        "name": "internal",
+                        "world": {
+                            "frame_type": "static",
+                            "frame": {
+                                "id": "world",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                }
+                            }
+                        },
+                        "frames": {
+                            "ceiling": {
+                                "frame_type": "static",
+                                "frame": {
+                                    "id": "ceiling",
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "geometry": {
+                                        "type": "box",
+                                        "x": 1500,
+                                        "y": 1500,
+                                        "z": 10,
+                                        "r": 0,
+                                        "l": 0,
+                                        "translation": {
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        },
+                                        "orientation": {
+                                            "type": "quaternion",
+                                            "value": {
+                                                "W": 1,
+                                                "X": 0,
+                                                "Y": 0,
+                                                "Z": 0
+                                            }
+                                        },
+                                        "Label": "ceiling"
+                                    }
+                                }
+                            }
+                        },
+                        "parents": {
+                            "ceiling": "world"
+                        }
+                    },
+                    "primary_output_frame": "ceiling"
+                }
+            },
+            "obstacle-ceiling:ceiling": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "obstacle-ceiling:ceiling",
+                    "inner_frame": {
+                        "frame_type": "static",
+                        "frame": {
+                            "id": "ceiling",
+                            "translation": {
+                                "X": 0,
+                                "Y": 0,
+                                "Z": 0
+                            },
+                            "orientation": {
+                                "type": "quaternion",
+                                "value": {
+                                    "W": 1,
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                }
+                            },
+                            "geometry": {
+                                "type": "box",
+                                "x": 1500,
+                                "y": 1500,
+                                "z": 10,
+                                "r": 0,
+                                "l": 0,
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "Label": "ceiling"
+                            }
+                        }
+                    }
+                }
+            },
+            "obstacle-ceiling_origin": {
+                "frame_type": "tail_geometry_static",
+                "frame": {
+                    "id": "obstacle-ceiling_origin",
+                    "translation": {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 1000
+                    },
+                    "orientation": {
+                        "type": "quaternion",
+                        "value": {
+                            "W": 1,
+                            "X": 0,
+                            "Y": 0,
+                            "Z": 0
+                        }
+                    }
+                }
+            },
+            "obstacle-front-wall": {
+                "frame_type": "model",
+                "frame": {
+                    "name": "obstacle-front-wall",
+                    "model": {
+                        "name": "obstacle-front-wall",
+                        "links": [
+                            {
+                                "id": "front-wall",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "geometry": {
+                                    "type": "box",
+                                    "x": 10,
+                                    "y": 1045,
+                                    "z": 1000,
+                                    "r": 0,
+                                    "l": 0,
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "Label": "front-wall"
+                                },
+                                "parent": "world"
+                            }
+                        ]
+                    },
+                    "limits": [],
+                    "internal_fs": {
+                        "name": "internal",
+                        "world": {
+                            "frame_type": "static",
+                            "frame": {
+                                "id": "world",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                }
+                            }
+                        },
+                        "frames": {
+                            "front-wall": {
+                                "frame_type": "static",
+                                "frame": {
+                                    "id": "front-wall",
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "geometry": {
+                                        "type": "box",
+                                        "x": 10,
+                                        "y": 1045,
+                                        "z": 1000,
+                                        "r": 0,
+                                        "l": 0,
+                                        "translation": {
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        },
+                                        "orientation": {
+                                            "type": "quaternion",
+                                            "value": {
+                                                "W": 1,
+                                                "X": 0,
+                                                "Y": 0,
+                                                "Z": 0
+                                            }
+                                        },
+                                        "Label": "front-wall"
+                                    }
+                                }
+                            }
+                        },
+                        "parents": {
+                            "front-wall": "world"
+                        }
+                    },
+                    "primary_output_frame": "front-wall"
+                }
+            },
+            "obstacle-front-wall:front-wall": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "obstacle-front-wall:front-wall",
+                    "inner_frame": {
+                        "frame_type": "static",
+                        "frame": {
+                            "id": "front-wall",
+                            "translation": {
+                                "X": 0,
+                                "Y": 0,
+                                "Z": 0
+                            },
+                            "orientation": {
+                                "type": "quaternion",
+                                "value": {
+                                    "W": 1,
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                }
+                            },
+                            "geometry": {
+                                "type": "box",
+                                "x": 10,
+                                "y": 1045,
+                                "z": 1000,
+                                "r": 0,
+                                "l": 0,
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "Label": "front-wall"
+                            }
+                        }
+                    }
+                }
+            },
+            "obstacle-front-wall_origin": {
+                "frame_type": "tail_geometry_static",
+                "frame": {
+                    "id": "obstacle-front-wall_origin",
+                    "translation": {
+                        "X": 960,
+                        "Y": 0,
+                        "Z": 500
+                    },
+                    "orientation": {
+                        "type": "quaternion",
+                        "value": {
+                            "W": 1,
+                            "X": 0,
+                            "Y": 0,
+                            "Z": 0
+                        }
+                    }
+                }
+            },
+            "obstacle-left-monitor": {
+                "frame_type": "model",
+                "frame": {
+                    "name": "obstacle-left-monitor",
+                    "model": {
+                        "name": "obstacle-left-monitor",
+                        "links": [
+                            {
+                                "id": "left-monitor",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "geometry": {
+                                    "type": "box",
+                                    "x": 300,
+                                    "y": 300,
+                                    "z": 300,
+                                    "r": 0,
+                                    "l": 0,
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "Label": "left-monitor"
+                                },
+                                "parent": "world"
+                            }
+                        ]
+                    },
+                    "limits": [],
+                    "internal_fs": {
+                        "name": "internal",
+                        "world": {
+                            "frame_type": "static",
+                            "frame": {
+                                "id": "world",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                }
+                            }
+                        },
+                        "frames": {
+                            "left-monitor": {
+                                "frame_type": "static",
+                                "frame": {
+                                    "id": "left-monitor",
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "geometry": {
+                                        "type": "box",
+                                        "x": 300,
+                                        "y": 300,
+                                        "z": 300,
+                                        "r": 0,
+                                        "l": 0,
+                                        "translation": {
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        },
+                                        "orientation": {
+                                            "type": "quaternion",
+                                            "value": {
+                                                "W": 1,
+                                                "X": 0,
+                                                "Y": 0,
+                                                "Z": 0
+                                            }
+                                        },
+                                        "Label": "left-monitor"
+                                    }
+                                }
+                            }
+                        },
+                        "parents": {
+                            "left-monitor": "world"
+                        }
+                    },
+                    "primary_output_frame": "left-monitor"
+                }
+            },
+            "obstacle-left-monitor:left-monitor": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "obstacle-left-monitor:left-monitor",
+                    "inner_frame": {
+                        "frame_type": "static",
+                        "frame": {
+                            "id": "left-monitor",
+                            "translation": {
+                                "X": 0,
+                                "Y": 0,
+                                "Z": 0
+                            },
+                            "orientation": {
+                                "type": "quaternion",
+                                "value": {
+                                    "W": 1,
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                }
+                            },
+                            "geometry": {
+                                "type": "box",
+                                "x": 300,
+                                "y": 300,
+                                "z": 300,
+                                "r": 0,
+                                "l": 0,
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "Label": "left-monitor"
+                            }
+                        }
+                    }
+                }
+            },
+            "obstacle-left-monitor_origin": {
+                "frame_type": "tail_geometry_static",
+                "frame": {
+                    "id": "obstacle-left-monitor_origin",
+                    "translation": {
+                        "X": 300,
+                        "Y": -260,
+                        "Z": 150
+                    },
+                    "orientation": {
+                        "type": "quaternion",
+                        "value": {
+                            "W": 1,
+                            "X": 0,
+                            "Y": 0,
+                            "Z": 0
+                        }
+                    }
+                }
+            },
+            "obstacle-left-wall": {
+                "frame_type": "model",
+                "frame": {
+                    "name": "obstacle-left-wall",
+                    "model": {
+                        "name": "obstacle-left-wall",
+                        "links": [
+                            {
+                                "id": "left-wall",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "geometry": {
+                                    "type": "box",
+                                    "x": 705,
+                                    "y": 40,
+                                    "z": 80,
+                                    "r": 0,
+                                    "l": 0,
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "Label": "left-wall"
+                                },
+                                "parent": "world"
+                            }
+                        ]
+                    },
+                    "limits": [],
+                    "internal_fs": {
+                        "name": "internal",
+                        "world": {
+                            "frame_type": "static",
+                            "frame": {
+                                "id": "world",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                }
+                            }
+                        },
+                        "frames": {
+                            "left-wall": {
+                                "frame_type": "static",
+                                "frame": {
+                                    "id": "left-wall",
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "geometry": {
+                                        "type": "box",
+                                        "x": 705,
+                                        "y": 40,
+                                        "z": 80,
+                                        "r": 0,
+                                        "l": 0,
+                                        "translation": {
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        },
+                                        "orientation": {
+                                            "type": "quaternion",
+                                            "value": {
+                                                "W": 1,
+                                                "X": 0,
+                                                "Y": 0,
+                                                "Z": 0
+                                            }
+                                        },
+                                        "Label": "left-wall"
+                                    }
+                                }
+                            }
+                        },
+                        "parents": {
+                            "left-wall": "world"
+                        }
+                    },
+                    "primary_output_frame": "left-wall"
+                }
+            },
+            "obstacle-left-wall:left-wall": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "obstacle-left-wall:left-wall",
+                    "inner_frame": {
+                        "frame_type": "static",
+                        "frame": {
+                            "id": "left-wall",
+                            "translation": {
+                                "X": 0,
+                                "Y": 0,
+                                "Z": 0
+                            },
+                            "orientation": {
+                                "type": "quaternion",
+                                "value": {
+                                    "W": 1,
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                }
+                            },
+                            "geometry": {
+                                "type": "box",
+                                "x": 705,
+                                "y": 40,
+                                "z": 80,
+                                "r": 0,
+                                "l": 0,
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "Label": "left-wall"
+                            }
+                        }
+                    }
+                }
+            },
+            "obstacle-left-wall_origin": {
+                "frame_type": "tail_geometry_static",
+                "frame": {
+                    "id": "obstacle-left-wall_origin",
+                    "translation": {
+                        "X": 162,
+                        "Y": -90,
+                        "Z": 40
+                    },
+                    "orientation": {
+                        "type": "quaternion",
+                        "value": {
+                            "W": 1,
+                            "X": 0,
+                            "Y": 0,
+                            "Z": 0
+                        }
+                    }
+                }
+            },
+            "obstacle-right-bottle": {
+                "frame_type": "model",
+                "frame": {
+                    "name": "obstacle-right-bottle",
+                    "model": {
+                        "name": "obstacle-right-bottle",
+                        "links": [
+                            {
+                                "id": "right-bottle",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "geometry": {
+                                    "type": "box",
+                                    "x": 85,
+                                    "y": 85,
+                                    "z": 320,
+                                    "r": 0,
+                                    "l": 0,
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "Label": "right-bottle"
+                                },
+                                "parent": "world"
+                            }
+                        ]
+                    },
+                    "limits": [],
+                    "internal_fs": {
+                        "name": "internal",
+                        "world": {
+                            "frame_type": "static",
+                            "frame": {
+                                "id": "world",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                }
+                            }
+                        },
+                        "frames": {
+                            "right-bottle": {
+                                "frame_type": "static",
+                                "frame": {
+                                    "id": "right-bottle",
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "geometry": {
+                                        "type": "box",
+                                        "x": 85,
+                                        "y": 85,
+                                        "z": 320,
+                                        "r": 0,
+                                        "l": 0,
+                                        "translation": {
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        },
+                                        "orientation": {
+                                            "type": "quaternion",
+                                            "value": {
+                                                "W": 1,
+                                                "X": 0,
+                                                "Y": 0,
+                                                "Z": 0
+                                            }
+                                        },
+                                        "Label": "right-bottle"
+                                    }
+                                }
+                            }
+                        },
+                        "parents": {
+                            "right-bottle": "world"
+                        }
+                    },
+                    "primary_output_frame": "right-bottle"
+                }
+            },
+            "obstacle-right-bottle:right-bottle": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "obstacle-right-bottle:right-bottle",
+                    "inner_frame": {
+                        "frame_type": "static",
+                        "frame": {
+                            "id": "right-bottle",
+                            "translation": {
+                                "X": 0,
+                                "Y": 0,
+                                "Z": 0
+                            },
+                            "orientation": {
+                                "type": "quaternion",
+                                "value": {
+                                    "W": 1,
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                }
+                            },
+                            "geometry": {
+                                "type": "box",
+                                "x": 85,
+                                "y": 85,
+                                "z": 320,
+                                "r": 0,
+                                "l": 0,
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "Label": "right-bottle"
+                            }
+                        }
+                    }
+                }
+            },
+            "obstacle-right-bottle_origin": {
+                "frame_type": "tail_geometry_static",
+                "frame": {
+                    "id": "obstacle-right-bottle_origin",
+                    "translation": {
+                        "X": -100,
+                        "Y": 500,
+                        "Z": 160
+                    },
+                    "orientation": {
+                        "type": "quaternion",
+                        "value": {
+                            "W": 1,
+                            "X": 0,
+                            "Y": 0,
+                            "Z": 0
+                        }
+                    }
+                }
+            },
+            "obstacle-right-wall": {
+                "frame_type": "model",
+                "frame": {
+                    "name": "obstacle-right-wall",
+                    "model": {
+                        "name": "obstacle-right-wall",
+                        "links": [
+                            {
+                                "id": "right-wall",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "geometry": {
+                                    "type": "box",
+                                    "x": 705,
+                                    "y": 40,
+                                    "z": 80,
+                                    "r": 0,
+                                    "l": 0,
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "Label": "right-wall"
+                                },
+                                "parent": "world"
+                            }
+                        ]
+                    },
+                    "limits": [],
+                    "internal_fs": {
+                        "name": "internal",
+                        "world": {
+                            "frame_type": "static",
+                            "frame": {
+                                "id": "world",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                }
+                            }
+                        },
+                        "frames": {
+                            "right-wall": {
+                                "frame_type": "static",
+                                "frame": {
+                                    "id": "right-wall",
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "geometry": {
+                                        "type": "box",
+                                        "x": 705,
+                                        "y": 40,
+                                        "z": 80,
+                                        "r": 0,
+                                        "l": 0,
+                                        "translation": {
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        },
+                                        "orientation": {
+                                            "type": "quaternion",
+                                            "value": {
+                                                "W": 1,
+                                                "X": 0,
+                                                "Y": 0,
+                                                "Z": 0
+                                            }
+                                        },
+                                        "Label": "right-wall"
+                                    }
+                                }
+                            }
+                        },
+                        "parents": {
+                            "right-wall": "world"
+                        }
+                    },
+                    "primary_output_frame": "right-wall"
+                }
+            },
+            "obstacle-right-wall:right-wall": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "obstacle-right-wall:right-wall",
+                    "inner_frame": {
+                        "frame_type": "static",
+                        "frame": {
+                            "id": "right-wall",
+                            "translation": {
+                                "X": 0,
+                                "Y": 0,
+                                "Z": 0
+                            },
+                            "orientation": {
+                                "type": "quaternion",
+                                "value": {
+                                    "W": 1,
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                }
+                            },
+                            "geometry": {
+                                "type": "box",
+                                "x": 705,
+                                "y": 40,
+                                "z": 80,
+                                "r": 0,
+                                "l": 0,
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "Label": "right-wall"
+                            }
+                        }
+                    }
+                }
+            },
+            "obstacle-right-wall_origin": {
+                "frame_type": "tail_geometry_static",
+                "frame": {
+                    "id": "obstacle-right-wall_origin",
+                    "translation": {
+                        "X": 162,
+                        "Y": 920,
+                        "Z": 40
+                    },
+                    "orientation": {
+                        "type": "quaternion",
+                        "value": {
+                            "W": 1,
+                            "X": 0,
+                            "Y": 0,
+                            "Z": 0
+                        }
+                    }
+                }
+            },
+            "obstacle-table": {
+                "frame_type": "model",
+                "frame": {
+                    "name": "obstacle-table",
+                    "model": {
+                        "name": "obstacle-table",
+                        "links": [
+                            {
+                                "id": "table",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "geometry": {
+                                    "type": "box",
+                                    "x": 705,
+                                    "y": 1045,
+                                    "z": 10,
+                                    "r": 0,
+                                    "l": 0,
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "Label": "table"
+                                },
+                                "parent": "world"
+                            }
+                        ]
+                    },
+                    "limits": [],
+                    "internal_fs": {
+                        "name": "internal",
+                        "world": {
+                            "frame_type": "static",
+                            "frame": {
+                                "id": "world",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                }
+                            }
+                        },
+                        "frames": {
+                            "table": {
+                                "frame_type": "static",
+                                "frame": {
+                                    "id": "table",
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "geometry": {
+                                        "type": "box",
+                                        "x": 705,
+                                        "y": 1045,
+                                        "z": 10,
+                                        "r": 0,
+                                        "l": 0,
+                                        "translation": {
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        },
+                                        "orientation": {
+                                            "type": "quaternion",
+                                            "value": {
+                                                "W": 1,
+                                                "X": 0,
+                                                "Y": 0,
+                                                "Z": 0
+                                            }
+                                        },
+                                        "Label": "table"
+                                    }
+                                }
+                            }
+                        },
+                        "parents": {
+                            "table": "world"
+                        }
+                    },
+                    "primary_output_frame": "table"
+                }
+            },
+            "obstacle-table-corner-left": {
+                "frame_type": "model",
+                "frame": {
+                    "name": "obstacle-table-corner-left",
+                    "model": {
+                        "name": "obstacle-table-corner-left",
+                        "links": [
+                            {
+                                "id": "left-corner",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "geometry": {
+                                    "type": "box",
+                                    "x": 240,
+                                    "y": 240,
+                                    "z": 80,
+                                    "r": 0,
+                                    "l": 0,
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "Label": "left-corner"
+                                },
+                                "parent": "world"
+                            }
+                        ]
+                    },
+                    "limits": [],
+                    "internal_fs": {
+                        "name": "internal",
+                        "world": {
+                            "frame_type": "static",
+                            "frame": {
+                                "id": "world",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                }
+                            }
+                        },
+                        "frames": {
+                            "left-corner": {
+                                "frame_type": "static",
+                                "frame": {
+                                    "id": "left-corner",
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "geometry": {
+                                        "type": "box",
+                                        "x": 240,
+                                        "y": 240,
+                                        "z": 80,
+                                        "r": 0,
+                                        "l": 0,
+                                        "translation": {
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        },
+                                        "orientation": {
+                                            "type": "quaternion",
+                                            "value": {
+                                                "W": 1,
+                                                "X": 0,
+                                                "Y": 0,
+                                                "Z": 0
+                                            }
+                                        },
+                                        "Label": "left-corner"
+                                    }
+                                }
+                            }
+                        },
+                        "parents": {
+                            "left-corner": "world"
+                        }
+                    },
+                    "primary_output_frame": "left-corner"
+                }
+            },
+            "obstacle-table-corner-left:left-corner": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "obstacle-table-corner-left:left-corner",
+                    "inner_frame": {
+                        "frame_type": "static",
+                        "frame": {
+                            "id": "left-corner",
+                            "translation": {
+                                "X": 0,
+                                "Y": 0,
+                                "Z": 0
+                            },
+                            "orientation": {
+                                "type": "quaternion",
+                                "value": {
+                                    "W": 1,
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                }
+                            },
+                            "geometry": {
+                                "type": "box",
+                                "x": 240,
+                                "y": 240,
+                                "z": 80,
+                                "r": 0,
+                                "l": 0,
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "Label": "left-corner"
+                            }
+                        }
+                    }
+                }
+            },
+            "obstacle-table-corner-left_origin": {
+                "frame_type": "tail_geometry_static",
+                "frame": {
+                    "id": "obstacle-table-corner-left_origin",
+                    "translation": {
+                        "X": 352,
+                        "Y": -20.000000000000014,
+                        "Z": 0
+                    },
+                    "orientation": {
+                        "type": "quaternion",
+                        "value": {
+                            "W": 0.9238795325112867,
+                            "X": 0,
+                            "Y": 0,
+                            "Z": 0.3826834323650898
+                        }
+                    }
+                }
+            },
+            "obstacle-table-corner-right": {
+                "frame_type": "model",
+                "frame": {
+                    "name": "obstacle-table-corner-right",
+                    "model": {
+                        "name": "obstacle-table-corner-right",
+                        "links": [
+                            {
+                                "id": "right-corner",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "geometry": {
+                                    "type": "box",
+                                    "x": 240,
+                                    "y": 240,
+                                    "z": 80,
+                                    "r": 0,
+                                    "l": 0,
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "Label": "right-corner"
+                                },
+                                "parent": "world"
+                            }
+                        ]
+                    },
+                    "limits": [],
+                    "internal_fs": {
+                        "name": "internal",
+                        "world": {
+                            "frame_type": "static",
+                            "frame": {
+                                "id": "world",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                }
+                            }
+                        },
+                        "frames": {
+                            "right-corner": {
+                                "frame_type": "static",
+                                "frame": {
+                                    "id": "right-corner",
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "geometry": {
+                                        "type": "box",
+                                        "x": 240,
+                                        "y": 240,
+                                        "z": 80,
+                                        "r": 0,
+                                        "l": 0,
+                                        "translation": {
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        },
+                                        "orientation": {
+                                            "type": "quaternion",
+                                            "value": {
+                                                "W": 1,
+                                                "X": 0,
+                                                "Y": 0,
+                                                "Z": 0
+                                            }
+                                        },
+                                        "Label": "right-corner"
+                                    }
+                                }
+                            }
+                        },
+                        "parents": {
+                            "right-corner": "world"
+                        }
+                    },
+                    "primary_output_frame": "right-corner"
+                }
+            },
+            "obstacle-table-corner-right:right-corner": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "obstacle-table-corner-right:right-corner",
+                    "inner_frame": {
+                        "frame_type": "static",
+                        "frame": {
+                            "id": "right-corner",
+                            "translation": {
+                                "X": 0,
+                                "Y": 0,
+                                "Z": 0
+                            },
+                            "orientation": {
+                                "type": "quaternion",
+                                "value": {
+                                    "W": 1,
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                }
+                            },
+                            "geometry": {
+                                "type": "box",
+                                "x": 240,
+                                "y": 240,
+                                "z": 80,
+                                "r": 0,
+                                "l": 0,
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "Label": "right-corner"
+                            }
+                        }
+                    }
+                }
+            },
+            "obstacle-table-corner-right_origin": {
+                "frame_type": "tail_geometry_static",
+                "frame": {
+                    "id": "obstacle-table-corner-right_origin",
+                    "translation": {
+                        "X": 352,
+                        "Y": 20,
+                        "Z": 0
+                    },
+                    "orientation": {
+                        "type": "quaternion",
+                        "value": {
+                            "W": 0.9238795325112867,
+                            "X": 0,
+                            "Y": 0,
+                            "Z": 0.3826834323650898
+                        }
+                    }
+                }
+            },
+            "obstacle-table:table": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "obstacle-table:table",
+                    "inner_frame": {
+                        "frame_type": "static",
+                        "frame": {
+                            "id": "table",
+                            "translation": {
+                                "X": 0,
+                                "Y": 0,
+                                "Z": 0
+                            },
+                            "orientation": {
+                                "type": "quaternion",
+                                "value": {
+                                    "W": 1,
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                }
+                            },
+                            "geometry": {
+                                "type": "box",
+                                "x": 705,
+                                "y": 1045,
+                                "z": 10,
+                                "r": 0,
+                                "l": 0,
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "Label": "table"
+                            }
+                        }
+                    }
+                }
+            },
+            "obstacle-table_origin": {
+                "frame_type": "tail_geometry_static",
+                "frame": {
+                    "id": "obstacle-table_origin",
+                    "translation": {
+                        "X": 162,
+                        "Y": 412,
+                        "Z": 0
+                    },
+                    "orientation": {
+                        "type": "quaternion",
+                        "value": {
+                            "W": 1,
+                            "X": 0,
+                            "Y": 0,
+                            "Z": 0
+                        }
+                    }
+                }
+            },
+            "right-arm": {
+                "frame_type": "model",
+                "frame": {
+                    "name": "right-arm",
+                    "model": {
+                        "name": "xArm6",
+                        "links": [
+                            {
+                                "id": "base",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": null,
+                                "geometry": {
+                                    "type": "",
+                                    "x": 0,
+                                    "y": 0,
+                                    "z": 0,
+                                    "r": 1,
+                                    "l": 0,
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": ""
+                                    },
+                                    "Label": ""
+                                },
+                                "parent": "world"
+                            },
+                            {
+                                "id": "base_top",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 267
+                                },
+                                "orientation": null,
+                                "geometry": {
+                                    "type": "",
+                                    "x": 0,
+                                    "y": 0,
+                                    "z": 0,
+                                    "r": 50,
+                                    "l": 320,
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 160
+                                    },
+                                    "orientation": {
+                                        "type": ""
+                                    },
+                                    "Label": ""
+                                },
+                                "parent": "waist"
+                            },
+                            {
+                                "id": "upper_arm",
+                                "translation": {
+                                    "X": 53.5,
+                                    "Y": 0,
+                                    "Z": 284.5
+                                },
+                                "orientation": null,
+                                "geometry": {
+                                    "type": "",
+                                    "x": 0,
+                                    "y": 0,
+                                    "z": 0,
+                                    "r": 70,
+                                    "l": 370,
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 40,
+                                        "Z": 135
+                                    },
+                                    "orientation": {
+                                        "type": "ov_degrees",
+                                        "value": {
+                                            "x": 0,
+                                            "y": -0.333,
+                                            "z": 0.666
+                                        }
+                                    },
+                                    "Label": ""
+                                },
+                                "parent": "shoulder"
+                            },
+                            {
+                                "id": "upper_forearm",
+                                "translation": {
+                                    "X": 77.5,
+                                    "Y": 0,
+                                    "Z": -172.5
+                                },
+                                "orientation": null,
+                                "geometry": {
+                                    "type": "",
+                                    "x": 80,
+                                    "y": 180,
+                                    "z": 250,
+                                    "r": 0,
+                                    "l": 0,
+                                    "translation": {
+                                        "X": 49.49,
+                                        "Y": 20,
+                                        "Z": -49.49
+                                    },
+                                    "orientation": {
+                                        "type": "ov_degrees",
+                                        "value": {
+                                            "th": 0,
+                                            "x": 0.707106,
+                                            "y": 0,
+                                            "z": -0.707106
+                                        }
+                                    },
+                                    "Label": ""
+                                },
+                                "parent": "elbow"
+                            },
+                            {
+                                "id": "lower_forearm",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": -170
+                                },
+                                "orientation": null,
+                                "geometry": {
+                                    "type": "",
+                                    "x": 0,
+                                    "y": 0,
+                                    "z": 0,
+                                    "r": 45,
+                                    "l": 285,
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": -27.5,
+                                        "Z": -104.8
+                                    },
+                                    "orientation": {
+                                        "type": "ov_degrees",
+                                        "value": {
+                                            "th": -90,
+                                            "x": 0,
+                                            "y": 0.2537568,
+                                            "z": 0.9672615
+                                        }
+                                    },
+                                    "Label": ""
+                                },
+                                "parent": "forearm_rot"
+                            },
+                            {
+                                "id": "wrist_link",
+                                "translation": {
+                                    "X": 76,
+                                    "Y": 0,
+                                    "Z": -97
+                                },
+                                "orientation": null,
+                                "geometry": {
+                                    "type": "",
+                                    "x": 150,
+                                    "y": 100,
+                                    "z": 125,
+                                    "r": 0,
+                                    "l": 0,
+                                    "translation": {
+                                        "X": 35,
+                                        "Y": 0,
+                                        "Z": -32.5
+                                    },
+                                    "orientation": {
+                                        "type": ""
+                                    },
+                                    "Label": ""
+                                },
+                                "parent": "wrist"
+                            },
+                            {
+                                "id": "gripper_mount",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "ov_degrees",
+                                    "value": {
+                                        "th": 0,
+                                        "x": 0,
+                                        "y": 0,
+                                        "z": -1
+                                    }
+                                },
+                                "geometry": {
+                                    "type": "",
+                                    "x": 0,
+                                    "y": 0,
+                                    "z": 0,
+                                    "r": 1,
+                                    "l": 0,
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": ""
+                                    },
+                                    "Label": ""
+                                },
+                                "parent": "gripper_rot"
+                            }
+                        ],
+                        "joints": [
+                            {
+                                "id": "waist",
+                                "type": "revolute",
+                                "parent": "base",
+                                "axis": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 1
+                                },
+                                "max": 359,
+                                "min": -359
+                            },
+                            {
+                                "id": "shoulder",
+                                "type": "revolute",
+                                "parent": "base_top",
+                                "axis": {
+                                    "X": 0,
+                                    "Y": 1,
+                                    "Z": 0
+                                },
+                                "max": 120,
+                                "min": -118
+                            },
+                            {
+                                "id": "elbow",
+                                "type": "revolute",
+                                "parent": "upper_arm",
+                                "axis": {
+                                    "X": 0,
+                                    "Y": 1,
+                                    "Z": 0
+                                },
+                                "max": 10,
+                                "min": -225
+                            },
+                            {
+                                "id": "forearm_rot",
+                                "type": "revolute",
+                                "parent": "upper_forearm",
+                                "axis": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": -1
+                                },
+                                "max": 359,
+                                "min": -359
+                            },
+                            {
+                                "id": "wrist",
+                                "type": "revolute",
+                                "parent": "lower_forearm",
+                                "axis": {
+                                    "X": 0,
+                                    "Y": 1,
+                                    "Z": 0
+                                },
+                                "max": 179,
+                                "min": -97
+                            },
+                            {
+                                "id": "gripper_rot",
+                                "type": "revolute",
+                                "parent": "wrist_link",
+                                "axis": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": -1
+                                },
+                                "max": 359,
+                                "min": -359
+                            }
+                        ],
+                        "original_file": {
+                            "bytes": "ewogICAgIm5hbWUiOiAieEFybTYiLAogICAgImxpbmtzIjogWwogICAgICAgIHsKICAgICAgICAgICAgImlkIjogImJhc2UiLAogICAgICAgICAgICAicGFyZW50IjogIndvcmxkIiwKICAgICAgICAgICAgInRyYW5zbGF0aW9uIjogewogICAgICAgICAgICAgICAgIngiOiAwLAogICAgICAgICAgICAgICAgInkiOiAwLAogICAgICAgICAgICAgICAgInoiOiAwCiAgICAgICAgICAgIH0sCiAgICAgICAgICAgICJnZW9tZXRyeSI6IHsKICAgICAgICAgICAgICAgICJyIjogMQogICAgICAgICAgICB9CiAgICAgICAgfSwKICAgICAgICB7CiAgICAgICAgICAgICJpZCI6ICJiYXNlX3RvcCIsCiAgICAgICAgICAgICJwYXJlbnQiOiAid2Fpc3QiLAogICAgICAgICAgICAidHJhbnNsYXRpb24iOiB7CiAgICAgICAgICAgICAgICAieCI6IDAsCiAgICAgICAgICAgICAgICAieSI6IDAsCiAgICAgICAgICAgICAgICAieiI6IDI2NwogICAgICAgICAgICB9LAogICAgICAgICAgICAiZ2VvbWV0cnkiOiB7CiAgICAgICAgICAgICAgICAiciI6IDUwLAogICAgICAgICAgICAgICAgImwiOiAzMjAsCiAgICAgICAgICAgICAgICAidHJhbnNsYXRpb24iOiB7CiAgICAgICAgICAgICAgICAgICAgIngiOiAwLAogICAgICAgICAgICAgICAgICAgICJ5IjogMCwKICAgICAgICAgICAgICAgICAgICAieiI6IDE2MAogICAgICAgICAgICAgICAgfQogICAgICAgICAgICB9CiAgICAgICAgfSwKICAgICAgICB7CiAgICAgICAgICAgICJpZCI6ICJ1cHBlcl9hcm0iLAogICAgICAgICAgICAicGFyZW50IjogInNob3VsZGVyIiwKICAgICAgICAgICAgInRyYW5zbGF0aW9uIjogewogICAgICAgICAgICAgICAgIngiOiA1My41LAogICAgICAgICAgICAgICAgInkiOiAwLAogICAgICAgICAgICAgICAgInoiOiAyODQuNQogICAgICAgICAgICB9LAogICAgICAgICAgICAiZ2VvbWV0cnkiOiB7CiAgICAgICAgICAgICAgICAiciI6IDcwLAogICAgICAgICAgICAgICAgImwiOiAzNzAsCiAgICAgICAgICAgICAgICAidHJhbnNsYXRpb24iOiB7CiAgICAgICAgICAgICAgICAgICAgIngiOiAwLAogICAgICAgICAgICAgICAgICAgICJ5IjogNDAsCiAgICAgICAgICAgICAgICAgICAgInoiOiAxMzUKICAgICAgICAgICAgICAgIH0sCiAgICAgICAgICAgICAgICAib3JpZW50YXRpb24iIDogewogICAgICAgICAgICAgICAgICAgICJ0eXBlIiA6ICJvdl9kZWdyZWVzIiwKICAgICAgICAgICAgICAgICAgICAidmFsdWUiIDogewogICAgICAgICAgICAgICAgICAgICAgICAieCIgOiAwLAogICAgICAgICAgICAgICAgICAgICAgICAieSIgOiAtMC4zMzMsCiAgICAgICAgICAgICAgICAgICAgICAgICJ6IiA6ICAwLjY2NgogICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgfQogICAgICAgIH0sCiAgICAgICAgewogICAgICAgICAgICAiaWQiOiAidXBwZXJfZm9yZWFybSIsCiAgICAgICAgICAgICJwYXJlbnQiOiAiZWxib3ciLAogICAgICAgICAgICAidHJhbnNsYXRpb24iOiB7CiAgICAgICAgICAgICAgICAieCI6IDc3LjUsCiAgICAgICAgICAgICAgICAieSI6IDAsCiAgICAgICAgICAgICAgICAieiI6IC0xNzIuNQogICAgICAgICAgICB9LAogICAgICAgICAgICAiZ2VvbWV0cnkiOiB7CiAgICAgICAgICAgICAgICAieCI6IDgwLAogICAgICAgICAgICAgICAgInkiOiAxODAsCiAgICAgICAgICAgICAgICAieiI6IDI1MCwKICAgICAgICAgICAgICAgICJ0cmFuc2xhdGlvbiI6IHsKICAgICAgICAgICAgICAgICAgICAieCI6IDQ5LjQ5LAogICAgICAgICAgICAgICAgICAgICJ5IjogMjAsCiAgICAgICAgICAgICAgICAgICAgInoiOiAtNDkuNDkKICAgICAgICAgICAgICAgIH0sCiAgICAgICAgICAgICAgICAib3JpZW50YXRpb24iOiB7CiAgICAgICAgICAgICAgICAgICAgInR5cGUiOiAib3ZfZGVncmVlcyIsCiAgICAgICAgICAgICAgICAgICAgInZhbHVlIjogewogICAgICAgICAgICAgICAgICAgICAgICAieCI6IDAuNzA3MTA2LAogICAgICAgICAgICAgICAgICAgICAgICAieSI6IDAsCiAgICAgICAgICAgICAgICAgICAgICAgICJ6IjogLTAuNzA3MTA2LAogICAgICAgICAgICAgICAgICAgICAgICAidGgiOiAwCiAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgfQogICAgICAgICAgICB9CiAgICAgICAgfSwKICAgICAgICB7CiAgICAgICAgICAgICJpZCI6ICJsb3dlcl9mb3JlYXJtIiwKICAgICAgICAgICAgInBhcmVudCI6ICJmb3JlYXJtX3JvdCIsCiAgICAgICAgICAgICJ0cmFuc2xhdGlvbiI6IHsKICAgICAgICAgICAgICAgICJ4IjogMCwKICAgICAgICAgICAgICAgICJ5IjogMCwKICAgICAgICAgICAgICAgICJ6IjogLTE3MAogICAgICAgICAgICB9LAogICAgICAgICAgICAiZ2VvbWV0cnkiOiB7CiAgICAgICAgICAgICAgICAiciI6IDQ1LAogICAgICAgICAgICAgICAgImwiOiAyODUsCiAgICAgICAgICAgICAgICAidHJhbnNsYXRpb24iOiB7CiAgICAgICAgICAgICAgICAgICAgIngiOiAwLAogICAgICAgICAgICAgICAgICAgICJ5IjogLTI3LjUsCiAgICAgICAgICAgICAgICAgICAgInoiOiAtMTA0LjgKICAgICAgICAgICAgICAgIH0sCiAgICAgICAgICAgICAgICAib3JpZW50YXRpb24iOiB7CiAgICAgICAgICAgICAgICAgICAgInR5cGUiOiAib3ZfZGVncmVlcyIsCiAgICAgICAgICAgICAgICAgICAgInZhbHVlIjogewogICAgICAgICAgICAgICAgICAgICAgICAidGgiOiAtOTAsCiAgICAgICAgICAgICAgICAgICAgICAgICJ4IjogMCwKICAgICAgICAgICAgICAgICAgICAgICAgInkiOiAwLjI1Mzc1NjgsCiAgICAgICAgICAgICAgICAgICAgICAgICJ6IjogMC45NjcyNjE1CiAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgfQogICAgICAgICAgICB9CiAgICAgICAgfSwKICAgICAgICB7CiAgICAgICAgICAgICJpZCI6ICJ3cmlzdF9saW5rIiwKICAgICAgICAgICAgInBhcmVudCI6ICJ3cmlzdCIsCiAgICAgICAgICAgICJ0cmFuc2xhdGlvbiI6IHsKICAgICAgICAgICAgICAgICJ4IjogNzYsCiAgICAgICAgICAgICAgICAieSI6IDAsCiAgICAgICAgICAgICAgICAieiI6IC05NwogICAgICAgICAgICB9LAogICAgICAgICAgICAiZ2VvbWV0cnkiOiB7CiAgICAgICAgICAgICAgICAieCI6IDE1MCwKICAgICAgICAgICAgICAgICJ5IjogMTAwLAogICAgICAgICAgICAgICAgInoiOiAxMjUsCiAgICAgICAgICAgICAgICAidHJhbnNsYXRpb24iOiB7CiAgICAgICAgICAgICAgICAgICAgIngiOiAzNSwKICAgICAgICAgICAgICAgICAgICAieSI6IDAsCiAgICAgICAgICAgICAgICAgICAgInoiOiAtMzIuNQogICAgICAgICAgICAgICAgfQogICAgICAgICAgICB9CiAgICAgICAgfSwKICAgICAgICB7CiAgICAgICAgICAgICJpZCI6ICJncmlwcGVyX21vdW50IiwKICAgICAgICAgICAgInBhcmVudCI6ICJncmlwcGVyX3JvdCIsCiAgICAgICAgICAgICJ0cmFuc2xhdGlvbiI6IHsKICAgICAgICAgICAgICAgICJ4IjogMCwKICAgICAgICAgICAgICAgICJ5IjogMCwKICAgICAgICAgICAgICAgICJ6IjogMAogICAgICAgICAgICB9LAogICAgICAgICAgICAib3JpZW50YXRpb24iOiB7CiAgICAgICAgICAgICAgICAidHlwZSI6ICJvdl9kZWdyZWVzIiwKICAgICAgICAgICAgICAgICJ2YWx1ZSI6IHsKICAgICAgICAgICAgICAgICAgICAieCI6IDAsCiAgICAgICAgICAgICAgICAgICAgInkiOiAwLAogICAgICAgICAgICAgICAgICAgICJ6IjogLTEsCiAgICAgICAgICAgICAgICAgICAgInRoIjogMAogICAgICAgICAgICAgICAgfQogICAgICAgICAgICB9LAogICAgICAgICAgICAiZ2VvbWV0cnkiOiB7CiAgICAgICAgICAgICAgICAiciI6IDEKICAgICAgICAgICAgfQogICAgICAgIH0KICAgIF0sCiAgICAiam9pbnRzIjogWwogICAgICAgIHsKICAgICAgICAgICAgImlkIjogIndhaXN0IiwKICAgICAgICAgICAgInR5cGUiOiAicmV2b2x1dGUiLAogICAgICAgICAgICAicGFyZW50IjogImJhc2UiLAogICAgICAgICAgICAiYXhpcyI6IHsKICAgICAgICAgICAgICAgICJ4IjogMCwKICAgICAgICAgICAgICAgICJ5IjogMCwKICAgICAgICAgICAgICAgICJ6IjogMQogICAgICAgICAgICB9LAogICAgICAgICAgICAibWF4IjogMzU5LAogICAgICAgICAgICAibWluIjogLTM1OQogICAgICAgIH0sCiAgICAgICAgewogICAgICAgICAgICAiaWQiOiAic2hvdWxkZXIiLAogICAgICAgICAgICAidHlwZSI6ICJyZXZvbHV0ZSIsCiAgICAgICAgICAgICJwYXJlbnQiOiAiYmFzZV90b3AiLAogICAgICAgICAgICAiYXhpcyI6IHsKICAgICAgICAgICAgICAgICJ4IjogMCwKICAgICAgICAgICAgICAgICJ5IjogMSwKICAgICAgICAgICAgICAgICJ6IjogMAogICAgICAgICAgICB9LAogICAgICAgICAgICAibWF4IjogMTIwLAogICAgICAgICAgICAibWluIjogLTExOAogICAgICAgIH0sCiAgICAgICAgewogICAgICAgICAgICAiaWQiOiAiZWxib3ciLAogICAgICAgICAgICAidHlwZSI6ICJyZXZvbHV0ZSIsCiAgICAgICAgICAgICJwYXJlbnQiOiAidXBwZXJfYXJtIiwKICAgICAgICAgICAgImF4aXMiOiB7CiAgICAgICAgICAgICAgICAieCI6IDAsCiAgICAgICAgICAgICAgICAieSI6IDEsCiAgICAgICAgICAgICAgICAieiI6IDAKICAgICAgICAgICAgfSwKICAgICAgICAgICAgIm1heCI6IDEwLAogICAgICAgICAgICAibWluIjogLTIyNQogICAgICAgIH0sCiAgICAgICAgewogICAgICAgICAgICAiaWQiOiAiZm9yZWFybV9yb3QiLAogICAgICAgICAgICAidHlwZSI6ICJyZXZvbHV0ZSIsCiAgICAgICAgICAgICJwYXJlbnQiOiAidXBwZXJfZm9yZWFybSIsCiAgICAgICAgICAgICJheGlzIjogewogICAgICAgICAgICAgICAgIngiOiAwLAogICAgICAgICAgICAgICAgInkiOiAwLAogICAgICAgICAgICAgICAgInoiOiAtMQogICAgICAgICAgICB9LAogICAgICAgICAgICAibWF4IjogMzU5LAogICAgICAgICAgICAibWluIjogLTM1OQogICAgICAgIH0sCiAgICAgICAgewogICAgICAgICAgICAiaWQiOiAid3Jpc3QiLAogICAgICAgICAgICAidHlwZSI6ICJyZXZvbHV0ZSIsCiAgICAgICAgICAgICJwYXJlbnQiOiAibG93ZXJfZm9yZWFybSIsCiAgICAgICAgICAgICJheGlzIjogewogICAgICAgICAgICAgICAgIngiOiAwLAogICAgICAgICAgICAgICAgInkiOiAxLAogICAgICAgICAgICAgICAgInoiOiAwCiAgICAgICAgICAgIH0sCiAgICAgICAgICAgICJtYXgiOiAxNzksCiAgICAgICAgICAgICJtaW4iOiAtOTcKICAgICAgICB9LAogICAgICAgIHsKICAgICAgICAgICAgImlkIjogImdyaXBwZXJfcm90IiwKICAgICAgICAgICAgInR5cGUiOiAicmV2b2x1dGUiLAogICAgICAgICAgICAicGFyZW50IjogIndyaXN0X2xpbmsiLAogICAgICAgICAgICAiYXhpcyI6IHsKICAgICAgICAgICAgICAgICJ4IjogMCwKICAgICAgICAgICAgICAgICJ5IjogMCwKICAgICAgICAgICAgICAgICJ6IjogLTEKICAgICAgICAgICAgfSwKICAgICAgICAgICAgIm1heCI6IDM1OSwKICAgICAgICAgICAgIm1pbiI6IC0zNTkKICAgICAgICB9CiAgICBdCn0K",
+                            "extension": "json"
+                        }
+                    },
+                    "limits": [
+                        {
+                            "Min": -6.265732014659642,
+                            "Max": 6.265732014659642
+                        },
+                        {
+                            "Min": -2.0594885173533086,
+                            "Max": 2.0943951023931953
+                        },
+                        {
+                            "Min": -3.9269908169872414,
+                            "Max": 0.17453292519943295
+                        },
+                        {
+                            "Min": -6.265732014659642,
+                            "Max": 6.265732014659642
+                        },
+                        {
+                            "Min": -1.6929693744344996,
+                            "Max": 3.12413936106985
+                        },
+                        {
+                            "Min": -6.265732014659642,
+                            "Max": 6.265732014659642
+                        }
+                    ],
+                    "internal_fs": {
+                        "name": "internal",
+                        "world": {
+                            "frame_type": "static",
+                            "frame": {
+                                "id": "world",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                }
+                            }
+                        },
+                        "frames": {
+                            "base": {
+                                "frame_type": "static",
+                                "frame": {
+                                    "id": "base",
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "geometry": {
+                                        "type": "sphere",
+                                        "x": 0,
+                                        "y": 0,
+                                        "z": 0,
+                                        "r": 1,
+                                        "l": 0,
+                                        "translation": {
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        },
+                                        "orientation": {
+                                            "type": "quaternion",
+                                            "value": {
+                                                "W": 1,
+                                                "X": 0,
+                                                "Y": 0,
+                                                "Z": 0
+                                            }
+                                        },
+                                        "Label": "base"
+                                    }
+                                }
+                            },
+                            "base_top": {
+                                "frame_type": "static",
+                                "frame": {
+                                    "id": "base_top",
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 267
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "geometry": {
+                                        "type": "capsule",
+                                        "x": 0,
+                                        "y": 0,
+                                        "z": 0,
+                                        "r": 50,
+                                        "l": 320,
+                                        "translation": {
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 160
+                                        },
+                                        "orientation": {
+                                            "type": "quaternion",
+                                            "value": {
+                                                "W": 1,
+                                                "X": 0,
+                                                "Y": 0,
+                                                "Z": 0
+                                            }
+                                        },
+                                        "Label": "base_top"
+                                    }
+                                }
+                            },
+                            "elbow": {
+                                "frame_type": "rotational",
+                                "frame": {
+                                    "id": "elbow",
+                                    "type": "revolute",
+                                    "parent": "",
+                                    "axis": {
+                                        "X": 0,
+                                        "Y": 1,
+                                        "Z": 0
+                                    },
+                                    "max": 10,
+                                    "min": -225
+                                }
+                            },
+                            "forearm_rot": {
+                                "frame_type": "rotational",
+                                "frame": {
+                                    "id": "forearm_rot",
+                                    "type": "revolute",
+                                    "parent": "",
+                                    "axis": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": -1
+                                    },
+                                    "max": 359,
+                                    "min": -359
+                                }
+                            },
+                            "gripper_mount": {
+                                "frame_type": "static",
+                                "frame": {
+                                    "id": "gripper_mount",
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 6.123233995736757e-17,
+                                            "X": 0,
+                                            "Y": 1,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "geometry": {
+                                        "type": "sphere",
+                                        "x": 0,
+                                        "y": 0,
+                                        "z": 0,
+                                        "r": 1,
+                                        "l": 0,
+                                        "translation": {
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        },
+                                        "orientation": {
+                                            "type": "quaternion",
+                                            "value": {
+                                                "W": 1,
+                                                "X": 0,
+                                                "Y": 0,
+                                                "Z": 0
+                                            }
+                                        },
+                                        "Label": "gripper_mount"
+                                    }
+                                }
+                            },
+                            "gripper_rot": {
+                                "frame_type": "rotational",
+                                "frame": {
+                                    "id": "gripper_rot",
+                                    "type": "revolute",
+                                    "parent": "",
+                                    "axis": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": -1
+                                    },
+                                    "max": 359,
+                                    "min": -359
+                                }
+                            },
+                            "lower_forearm": {
+                                "frame_type": "static",
+                                "frame": {
+                                    "id": "lower_forearm",
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": -170
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "geometry": {
+                                        "type": "capsule",
+                                        "x": 0,
+                                        "y": 0,
+                                        "z": 0,
+                                        "r": 45,
+                                        "l": 285,
+                                        "translation": {
+                                            "X": 1.4791141972893971e-31,
+                                            "Y": -27.499999999999993,
+                                            "Z": -104.79999999999995
+                                        },
+                                        "orientation": {
+                                            "type": "quaternion",
+                                            "value": {
+                                                "W": 0.9917831494535221,
+                                                "X": -0.12793038911866228,
+                                                "Y": 1.3877787807814457e-17,
+                                                "Z": -5.551115123125783e-17
+                                            }
+                                        },
+                                        "Label": "lower_forearm"
+                                    }
+                                }
+                            },
+                            "shoulder": {
+                                "frame_type": "rotational",
+                                "frame": {
+                                    "id": "shoulder",
+                                    "type": "revolute",
+                                    "parent": "",
+                                    "axis": {
+                                        "X": 0,
+                                        "Y": 1,
+                                        "Z": 0
+                                    },
+                                    "max": 119.99999999999999,
+                                    "min": -118
+                                }
+                            },
+                            "upper_arm": {
+                                "frame_type": "static",
+                                "frame": {
+                                    "id": "upper_arm",
+                                    "translation": {
+                                        "X": 53.5,
+                                        "Y": 0,
+                                        "Z": 284.5
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "geometry": {
+                                        "type": "capsule",
+                                        "x": 0,
+                                        "y": 0,
+                                        "z": 0,
+                                        "r": 70,
+                                        "l": 370,
+                                        "translation": {
+                                            "X": -5.329070518200751e-15,
+                                            "Y": 39.99999999999999,
+                                            "Z": 135
+                                        },
+                                        "orientation": {
+                                            "type": "quaternion",
+                                            "value": {
+                                                "W": 0.6881909602355868,
+                                                "X": 0.1624598481164531,
+                                                "Y": 0.16245984811645311,
+                                                "Z": -0.6881909602355867
+                                            }
+                                        },
+                                        "Label": "upper_arm"
+                                    }
+                                }
+                            },
+                            "upper_forearm": {
+                                "frame_type": "static",
+                                "frame": {
+                                    "id": "upper_forearm",
+                                    "translation": {
+                                        "X": 77.5,
+                                        "Y": 0,
+                                        "Z": -172.5
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "geometry": {
+                                        "type": "box",
+                                        "x": 80,
+                                        "y": 180,
+                                        "z": 250,
+                                        "r": 0,
+                                        "l": 0,
+                                        "translation": {
+                                            "X": 49.49,
+                                            "Y": 20,
+                                            "Z": -49.49
+                                        },
+                                        "orientation": {
+                                            "type": "quaternion",
+                                            "value": {
+                                                "W": 0.38268343236508984,
+                                                "X": 0,
+                                                "Y": 0.9238795325112867,
+                                                "Z": 0
+                                            }
+                                        },
+                                        "Label": "upper_forearm"
+                                    }
+                                }
+                            },
+                            "waist": {
+                                "frame_type": "rotational",
+                                "frame": {
+                                    "id": "waist",
+                                    "type": "revolute",
+                                    "parent": "",
+                                    "axis": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 1
+                                    },
+                                    "max": 359,
+                                    "min": -359
+                                }
+                            },
+                            "wrist": {
+                                "frame_type": "rotational",
+                                "frame": {
+                                    "id": "wrist",
+                                    "type": "revolute",
+                                    "parent": "",
+                                    "axis": {
+                                        "X": 0,
+                                        "Y": 1,
+                                        "Z": 0
+                                    },
+                                    "max": 179,
+                                    "min": -97
+                                }
+                            },
+                            "wrist_link": {
+                                "frame_type": "static",
+                                "frame": {
+                                    "id": "wrist_link",
+                                    "translation": {
+                                        "X": 76,
+                                        "Y": 0,
+                                        "Z": -97
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "geometry": {
+                                        "type": "box",
+                                        "x": 150,
+                                        "y": 100,
+                                        "z": 125,
+                                        "r": 0,
+                                        "l": 0,
+                                        "translation": {
+                                            "X": 35,
+                                            "Y": 0,
+                                            "Z": -32.5
+                                        },
+                                        "orientation": {
+                                            "type": "quaternion",
+                                            "value": {
+                                                "W": 1,
+                                                "X": 0,
+                                                "Y": 0,
+                                                "Z": 0
+                                            }
+                                        },
+                                        "Label": "wrist_link"
+                                    }
+                                }
+                            }
+                        },
+                        "parents": {
+                            "base": "world",
+                            "base_top": "waist",
+                            "elbow": "upper_arm",
+                            "forearm_rot": "upper_forearm",
+                            "gripper_mount": "gripper_rot",
+                            "gripper_rot": "wrist_link",
+                            "lower_forearm": "forearm_rot",
+                            "shoulder": "base_top",
+                            "upper_arm": "shoulder",
+                            "upper_forearm": "elbow",
+                            "waist": "base",
+                            "wrist": "lower_forearm",
+                            "wrist_link": "wrist"
+                        }
+                    },
+                    "primary_output_frame": "gripper_mount"
+                }
+            },
+            "right-arm:base": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "right-arm:base",
+                    "inner_frame": {
+                        "frame_type": "static",
+                        "frame": {
+                            "id": "base",
+                            "translation": {
+                                "X": 0,
+                                "Y": 0,
+                                "Z": 0
+                            },
+                            "orientation": {
+                                "type": "quaternion",
+                                "value": {
+                                    "W": 1,
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                }
+                            },
+                            "geometry": {
+                                "type": "sphere",
+                                "x": 0,
+                                "y": 0,
+                                "z": 0,
+                                "r": 1,
+                                "l": 0,
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "Label": "base"
+                            }
+                        }
+                    }
+                }
+            },
+            "right-arm:base_top": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "right-arm:base_top",
+                    "inner_frame": {
+                        "frame_type": "static",
+                        "frame": {
+                            "id": "base_top",
+                            "translation": {
+                                "X": 0,
+                                "Y": 0,
+                                "Z": 267
+                            },
+                            "orientation": {
+                                "type": "quaternion",
+                                "value": {
+                                    "W": 1,
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                }
+                            },
+                            "geometry": {
+                                "type": "capsule",
+                                "x": 0,
+                                "y": 0,
+                                "z": 0,
+                                "r": 50,
+                                "l": 320,
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 160
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "Label": "base_top"
+                            }
+                        }
+                    }
+                }
+            },
+            "right-arm:elbow": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "right-arm:elbow",
+                    "inner_frame": {
+                        "frame_type": "rotational",
+                        "frame": {
+                            "id": "elbow",
+                            "type": "revolute",
+                            "parent": "",
+                            "axis": {
+                                "X": 0,
+                                "Y": 1,
+                                "Z": 0
+                            },
+                            "max": 10,
+                            "min": -225
+                        }
+                    }
+                }
+            },
+            "right-arm:forearm_rot": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "right-arm:forearm_rot",
+                    "inner_frame": {
+                        "frame_type": "rotational",
+                        "frame": {
+                            "id": "forearm_rot",
+                            "type": "revolute",
+                            "parent": "",
+                            "axis": {
+                                "X": 0,
+                                "Y": 0,
+                                "Z": -1
+                            },
+                            "max": 359,
+                            "min": -359
+                        }
+                    }
+                }
+            },
+            "right-arm:gripper_mount": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "right-arm:gripper_mount",
+                    "inner_frame": {
+                        "frame_type": "static",
+                        "frame": {
+                            "id": "gripper_mount",
+                            "translation": {
+                                "X": 0,
+                                "Y": 0,
+                                "Z": 0
+                            },
+                            "orientation": {
+                                "type": "quaternion",
+                                "value": {
+                                    "W": 6.123233995736757e-17,
+                                    "X": 0,
+                                    "Y": 1,
+                                    "Z": 0
+                                }
+                            },
+                            "geometry": {
+                                "type": "sphere",
+                                "x": 0,
+                                "y": 0,
+                                "z": 0,
+                                "r": 1,
+                                "l": 0,
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "Label": "gripper_mount"
+                            }
+                        }
+                    }
+                }
+            },
+            "right-arm:gripper_rot": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "right-arm:gripper_rot",
+                    "inner_frame": {
+                        "frame_type": "rotational",
+                        "frame": {
+                            "id": "gripper_rot",
+                            "type": "revolute",
+                            "parent": "",
+                            "axis": {
+                                "X": 0,
+                                "Y": 0,
+                                "Z": -1
+                            },
+                            "max": 359,
+                            "min": -359
+                        }
+                    }
+                }
+            },
+            "right-arm:lower_forearm": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "right-arm:lower_forearm",
+                    "inner_frame": {
+                        "frame_type": "static",
+                        "frame": {
+                            "id": "lower_forearm",
+                            "translation": {
+                                "X": 0,
+                                "Y": 0,
+                                "Z": -170
+                            },
+                            "orientation": {
+                                "type": "quaternion",
+                                "value": {
+                                    "W": 1,
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                }
+                            },
+                            "geometry": {
+                                "type": "capsule",
+                                "x": 0,
+                                "y": 0,
+                                "z": 0,
+                                "r": 45,
+                                "l": 285,
+                                "translation": {
+                                    "X": 1.4791141972893971e-31,
+                                    "Y": -27.499999999999993,
+                                    "Z": -104.79999999999995
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 0.9917831494535221,
+                                        "X": -0.12793038911866228,
+                                        "Y": 1.3877787807814457e-17,
+                                        "Z": -5.551115123125783e-17
+                                    }
+                                },
+                                "Label": "lower_forearm"
+                            }
+                        }
+                    }
+                }
+            },
+            "right-arm:shoulder": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "right-arm:shoulder",
+                    "inner_frame": {
+                        "frame_type": "rotational",
+                        "frame": {
+                            "id": "shoulder",
+                            "type": "revolute",
+                            "parent": "",
+                            "axis": {
+                                "X": 0,
+                                "Y": 1,
+                                "Z": 0
+                            },
+                            "max": 119.99999999999999,
+                            "min": -118
+                        }
+                    }
+                }
+            },
+            "right-arm:upper_arm": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "right-arm:upper_arm",
+                    "inner_frame": {
+                        "frame_type": "static",
+                        "frame": {
+                            "id": "upper_arm",
+                            "translation": {
+                                "X": 53.5,
+                                "Y": 0,
+                                "Z": 284.5
+                            },
+                            "orientation": {
+                                "type": "quaternion",
+                                "value": {
+                                    "W": 1,
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                }
+                            },
+                            "geometry": {
+                                "type": "capsule",
+                                "x": 0,
+                                "y": 0,
+                                "z": 0,
+                                "r": 70,
+                                "l": 370,
+                                "translation": {
+                                    "X": -5.329070518200751e-15,
+                                    "Y": 39.99999999999999,
+                                    "Z": 135
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 0.6881909602355868,
+                                        "X": 0.1624598481164531,
+                                        "Y": 0.16245984811645311,
+                                        "Z": -0.6881909602355867
+                                    }
+                                },
+                                "Label": "upper_arm"
+                            }
+                        }
+                    }
+                }
+            },
+            "right-arm:upper_forearm": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "right-arm:upper_forearm",
+                    "inner_frame": {
+                        "frame_type": "static",
+                        "frame": {
+                            "id": "upper_forearm",
+                            "translation": {
+                                "X": 77.5,
+                                "Y": 0,
+                                "Z": -172.5
+                            },
+                            "orientation": {
+                                "type": "quaternion",
+                                "value": {
+                                    "W": 1,
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                }
+                            },
+                            "geometry": {
+                                "type": "box",
+                                "x": 80,
+                                "y": 180,
+                                "z": 250,
+                                "r": 0,
+                                "l": 0,
+                                "translation": {
+                                    "X": 49.49,
+                                    "Y": 20,
+                                    "Z": -49.49
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 0.38268343236508984,
+                                        "X": 0,
+                                        "Y": 0.9238795325112867,
+                                        "Z": 0
+                                    }
+                                },
+                                "Label": "upper_forearm"
+                            }
+                        }
+                    }
+                }
+            },
+            "right-arm:waist": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "right-arm:waist",
+                    "inner_frame": {
+                        "frame_type": "rotational",
+                        "frame": {
+                            "id": "waist",
+                            "type": "revolute",
+                            "parent": "",
+                            "axis": {
+                                "X": 0,
+                                "Y": 0,
+                                "Z": 1
+                            },
+                            "max": 359,
+                            "min": -359
+                        }
+                    }
+                }
+            },
+            "right-arm:wrist": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "right-arm:wrist",
+                    "inner_frame": {
+                        "frame_type": "rotational",
+                        "frame": {
+                            "id": "wrist",
+                            "type": "revolute",
+                            "parent": "",
+                            "axis": {
+                                "X": 0,
+                                "Y": 1,
+                                "Z": 0
+                            },
+                            "max": 179,
+                            "min": -97
+                        }
+                    }
+                }
+            },
+            "right-arm:wrist_link": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "right-arm:wrist_link",
+                    "inner_frame": {
+                        "frame_type": "static",
+                        "frame": {
+                            "id": "wrist_link",
+                            "translation": {
+                                "X": 76,
+                                "Y": 0,
+                                "Z": -97
+                            },
+                            "orientation": {
+                                "type": "quaternion",
+                                "value": {
+                                    "W": 1,
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                }
+                            },
+                            "geometry": {
+                                "type": "box",
+                                "x": 150,
+                                "y": 100,
+                                "z": 125,
+                                "r": 0,
+                                "l": 0,
+                                "translation": {
+                                    "X": 35,
+                                    "Y": 0,
+                                    "Z": -32.5
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "Label": "wrist_link"
+                            }
+                        }
+                    }
+                }
+            },
+            "right-arm_origin": {
+                "frame_type": "tail_geometry_static",
+                "frame": {
+                    "id": "right-arm_origin",
+                    "translation": {
+                        "X": -5,
+                        "Y": 825.0000000000002,
+                        "Z": 0
+                    },
+                    "orientation": {
+                        "type": "quaternion",
+                        "value": {
+                            "W": 0.9659258262890683,
+                            "X": 0,
+                            "Y": 0,
+                            "Z": 0.25881904510252074
+                        }
+                    }
+                }
+            },
+            "right-cam": {
+                "frame_type": "static",
+                "frame": {
+                    "id": "right-cam",
+                    "translation": {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 0
+                    },
+                    "orientation": {
+                        "type": "quaternion",
+                        "value": {
+                            "W": 1,
+                            "X": 0,
+                            "Y": 0,
+                            "Z": 0
+                        }
+                    }
+                }
+            },
+            "right-cam_origin": {
+                "frame_type": "tail_geometry_static",
+                "frame": {
+                    "id": "right-cam_origin",
+                    "translation": {
+                        "X": 80,
+                        "Y": -34.999999999999986,
+                        "Z": 35
+                    },
+                    "orientation": {
+                        "type": "quaternion",
+                        "value": {
+                            "W": -0.7137227636428367,
+                            "X": 0.009380437494157626,
+                            "Y": 0.012086963587744436,
+                            "Z": -0.7002611865309102
+                        }
+                    },
+                    "geometry": {
+                        "type": "box",
+                        "x": 90,
+                        "y": 25,
+                        "z": 25,
+                        "r": 0,
+                        "l": 0,
+                        "translation": {
+                            "X": 32.2,
+                            "Y": 0,
+                            "Z": -8.3
+                        },
+                        "orientation": {
+                            "type": "quaternion",
+                            "value": {
+                                "W": 1,
+                                "X": 0,
+                                "Y": 0,
+                                "Z": 0
+                            }
+                        },
+                        "Label": "right-cam_origin"
+                    }
+                }
+            },
+            "right-gripper": {
+                "frame_type": "model",
+                "frame": {
+                    "name": "right-gripper",
+                    "model": {
+                        "name": "right-gripper",
+                        "links": [
+                            {
+                                "id": "case-gripper",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "geometry": {
+                                    "type": "box",
+                                    "x": 50,
+                                    "y": 100,
+                                    "z": 100,
+                                    "r": 0,
+                                    "l": 0,
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": -50
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "Label": "case-gripper"
+                                },
+                                "parent": "world"
+                            },
+                            {
+                                "id": "claws",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "geometry": {
+                                    "type": "box",
+                                    "x": 40,
+                                    "y": 170,
+                                    "z": 105,
+                                    "r": 0,
+                                    "l": 0,
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": -2.5
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "Label": "claws"
+                                },
+                                "parent": "case-gripper"
+                            }
+                        ]
+                    },
+                    "limits": [],
+                    "internal_fs": {
+                        "name": "internal",
+                        "world": {
+                            "frame_type": "static",
+                            "frame": {
+                                "id": "world",
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                }
+                            }
+                        },
+                        "frames": {
+                            "case-gripper": {
+                                "frame_type": "static",
+                                "frame": {
+                                    "id": "case-gripper",
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "geometry": {
+                                        "type": "box",
+                                        "x": 50,
+                                        "y": 100,
+                                        "z": 100,
+                                        "r": 0,
+                                        "l": 0,
+                                        "translation": {
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": -50
+                                        },
+                                        "orientation": {
+                                            "type": "quaternion",
+                                            "value": {
+                                                "W": 1,
+                                                "X": 0,
+                                                "Y": 0,
+                                                "Z": 0
+                                            }
+                                        },
+                                        "Label": "case-gripper"
+                                    }
+                                }
+                            },
+                            "claws": {
+                                "frame_type": "static",
+                                "frame": {
+                                    "id": "claws",
+                                    "translation": {
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    },
+                                    "orientation": {
+                                        "type": "quaternion",
+                                        "value": {
+                                            "W": 1,
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": 0
+                                        }
+                                    },
+                                    "geometry": {
+                                        "type": "box",
+                                        "x": 40,
+                                        "y": 170,
+                                        "z": 105,
+                                        "r": 0,
+                                        "l": 0,
+                                        "translation": {
+                                            "X": 0,
+                                            "Y": 0,
+                                            "Z": -2.5
+                                        },
+                                        "orientation": {
+                                            "type": "quaternion",
+                                            "value": {
+                                                "W": 1,
+                                                "X": 0,
+                                                "Y": 0,
+                                                "Z": 0
+                                            }
+                                        },
+                                        "Label": "claws"
+                                    }
+                                }
+                            }
+                        },
+                        "parents": {
+                            "case-gripper": "world",
+                            "claws": "case-gripper"
+                        }
+                    },
+                    "primary_output_frame": "claws"
+                }
+            },
+            "right-gripper:case-gripper": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "right-gripper:case-gripper",
+                    "inner_frame": {
+                        "frame_type": "static",
+                        "frame": {
+                            "id": "case-gripper",
+                            "translation": {
+                                "X": 0,
+                                "Y": 0,
+                                "Z": 0
+                            },
+                            "orientation": {
+                                "type": "quaternion",
+                                "value": {
+                                    "W": 1,
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                }
+                            },
+                            "geometry": {
+                                "type": "box",
+                                "x": 50,
+                                "y": 100,
+                                "z": 100,
+                                "r": 0,
+                                "l": 0,
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": -50
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "Label": "case-gripper"
+                            }
+                        }
+                    }
+                }
+            },
+            "right-gripper:claws": {
+                "frame_type": "named",
+                "frame": {
+                    "name": "right-gripper:claws",
+                    "inner_frame": {
+                        "frame_type": "static",
+                        "frame": {
+                            "id": "claws",
+                            "translation": {
+                                "X": 0,
+                                "Y": 0,
+                                "Z": 0
+                            },
+                            "orientation": {
+                                "type": "quaternion",
+                                "value": {
+                                    "W": 1,
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": 0
+                                }
+                            },
+                            "geometry": {
+                                "type": "box",
+                                "x": 40,
+                                "y": 170,
+                                "z": 105,
+                                "r": 0,
+                                "l": 0,
+                                "translation": {
+                                    "X": 0,
+                                    "Y": 0,
+                                    "Z": -2.5
+                                },
+                                "orientation": {
+                                    "type": "quaternion",
+                                    "value": {
+                                        "W": 1,
+                                        "X": 0,
+                                        "Y": 0,
+                                        "Z": 0
+                                    }
+                                },
+                                "Label": "claws"
+                            }
+                        }
+                    }
+                }
+            },
+            "right-gripper_origin": {
+                "frame_type": "tail_geometry_static",
+                "frame": {
+                    "id": "right-gripper_origin",
+                    "translation": {
+                        "X": 0,
+                        "Y": 0,
+                        "Z": 150
+                    },
+                    "orientation": {
+                        "type": "quaternion",
+                        "value": {
+                            "W": 1,
+                            "X": 0,
+                            "Y": 0,
+                            "Z": 0
+                        }
+                    }
+                }
+            }
+        },
+        "parents": {
+            "cam-left-cup-crop": "cam-left-cup-crop_origin",
+            "cam-left-cup-crop_origin": "world",
+            "cam-merged-cup": "cam-merged-cup_origin",
+            "cam-merged-cup_origin": "world",
+            "left-arm": "left-arm_origin",
+            "left-arm:base": "left-arm_origin",
+            "left-arm:base_top": "left-arm:waist",
+            "left-arm:elbow": "left-arm:upper_arm",
+            "left-arm:forearm_rot": "left-arm:upper_forearm",
+            "left-arm:gripper_mount": "left-arm:gripper_rot",
+            "left-arm:gripper_rot": "left-arm:wrist_link",
+            "left-arm:lower_forearm": "left-arm:forearm_rot",
+            "left-arm:shoulder": "left-arm:base_top",
+            "left-arm:upper_arm": "left-arm:shoulder",
+            "left-arm:upper_forearm": "left-arm:elbow",
+            "left-arm:waist": "left-arm:base",
+            "left-arm:wrist": "left-arm:lower_forearm",
+            "left-arm:wrist_link": "left-arm:wrist",
+            "left-arm_origin": "world",
+            "left-cam": "left-cam_origin",
+            "left-cam_origin": "left-arm",
+            "left-gripper": "left-gripper_origin",
+            "left-gripper:case-gripper": "left-gripper_origin",
+            "left-gripper:claws": "left-gripper:case-gripper",
+            "left-gripper_origin": "left-arm",
+            "obstacle-arm-left-cord": "obstacle-arm-left-cord_origin",
+            "obstacle-arm-left-cord:arm-left-cord": "obstacle-arm-left-cord_origin",
+            "obstacle-arm-left-cord_origin": "left-arm",
+            "obstacle-back-wall": "obstacle-back-wall_origin",
+            "obstacle-back-wall:back-wall": "obstacle-back-wall_origin",
+            "obstacle-back-wall_origin": "world",
+            "obstacle-ceiling": "obstacle-ceiling_origin",
+            "obstacle-ceiling:ceiling": "obstacle-ceiling_origin",
+            "obstacle-ceiling_origin": "obstacle-table",
+            "obstacle-front-wall": "obstacle-front-wall_origin",
+            "obstacle-front-wall:front-wall": "obstacle-front-wall_origin",
+            "obstacle-front-wall_origin": "obstacle-table",
+            "obstacle-left-monitor": "obstacle-left-monitor_origin",
+            "obstacle-left-monitor:left-monitor": "obstacle-left-monitor_origin",
+            "obstacle-left-monitor_origin": "world",
+            "obstacle-left-wall": "obstacle-left-wall_origin",
+            "obstacle-left-wall:left-wall": "obstacle-left-wall_origin",
+            "obstacle-left-wall_origin": "world",
+            "obstacle-right-bottle": "obstacle-right-bottle_origin",
+            "obstacle-right-bottle:right-bottle": "obstacle-right-bottle_origin",
+            "obstacle-right-bottle_origin": "world",
+            "obstacle-right-wall": "obstacle-right-wall_origin",
+            "obstacle-right-wall:right-wall": "obstacle-right-wall_origin",
+            "obstacle-right-wall_origin": "world",
+            "obstacle-table": "obstacle-table_origin",
+            "obstacle-table-corner-left": "obstacle-table-corner-left_origin",
+            "obstacle-table-corner-left:left-corner": "obstacle-table-corner-left_origin",
+            "obstacle-table-corner-left_origin": "obstacle-left-wall",
+            "obstacle-table-corner-right": "obstacle-table-corner-right_origin",
+            "obstacle-table-corner-right:right-corner": "obstacle-table-corner-right_origin",
+            "obstacle-table-corner-right_origin": "obstacle-right-wall",
+            "obstacle-table:table": "obstacle-table_origin",
+            "obstacle-table_origin": "world",
+            "right-arm": "right-arm_origin",
+            "right-arm:base": "right-arm_origin",
+            "right-arm:base_top": "right-arm:waist",
+            "right-arm:elbow": "right-arm:upper_arm",
+            "right-arm:forearm_rot": "right-arm:upper_forearm",
+            "right-arm:gripper_mount": "right-arm:gripper_rot",
+            "right-arm:gripper_rot": "right-arm:wrist_link",
+            "right-arm:lower_forearm": "right-arm:forearm_rot",
+            "right-arm:shoulder": "right-arm:base_top",
+            "right-arm:upper_arm": "right-arm:shoulder",
+            "right-arm:upper_forearm": "right-arm:elbow",
+            "right-arm:waist": "right-arm:base",
+            "right-arm:wrist": "right-arm:lower_forearm",
+            "right-arm:wrist_link": "right-arm:wrist",
+            "right-arm_origin": "world",
+            "right-cam": "right-cam_origin",
+            "right-cam_origin": "right-arm",
+            "right-gripper": "right-gripper_origin",
+            "right-gripper:case-gripper": "right-gripper_origin",
+            "right-gripper:claws": "right-gripper:case-gripper",
+            "right-gripper_origin": "right-arm"
+        }
+    },
+    "goals": [
+        {
+            "poses": {
+                "left-gripper": {
+                    "referenceFrame": "world",
+                    "pose": {
+                        "x": 387.70400160800216,
+                        "y": 293.10390108369927,
+                        "z": 84,
+                        "oX": 0.9999999939338194,
+                        "oY": -0.00002305289444587489,
+                        "oZ": -0.00010770759041089306,
+                        "theta": -179.99642463867298
+                    }
+                }
+            },
+            "configuration": null
+        }
+    ],
+    "start_state": {
+        "poses": null,
+        "configuration": {
+            "cam-left-cup-crop": [],
+            "cam-left-cup-crop_origin": [],
+            "cam-merged-cup": [],
+            "cam-merged-cup_origin": [],
+            "left-arm": [
+                -4.652278900146484,
+                0.48613590002059937,
+                -0.6567204594612123,
+                4.2547607421875,
+                1.4947261810302734,
+                -0.1528232991695404
+            ],
+            "left-arm_origin": [],
+            "left-cam": [],
+            "left-cam_origin": [],
+            "left-gripper": [],
+            "left-gripper_origin": [],
+            "obstacle-arm-left-cord": [],
+            "obstacle-arm-left-cord_origin": [],
+            "obstacle-back-wall": [],
+            "obstacle-back-wall_origin": [],
+            "obstacle-ceiling": [],
+            "obstacle-ceiling_origin": [],
+            "obstacle-front-wall": [],
+            "obstacle-front-wall_origin": [],
+            "obstacle-left-monitor": [],
+            "obstacle-left-monitor_origin": [],
+            "obstacle-left-wall": [],
+            "obstacle-left-wall_origin": [],
+            "obstacle-right-bottle": [],
+            "obstacle-right-bottle_origin": [],
+            "obstacle-right-wall": [],
+            "obstacle-right-wall_origin": [],
+            "obstacle-table": [],
+            "obstacle-table-corner-left": [],
+            "obstacle-table-corner-left_origin": [],
+            "obstacle-table-corner-right": [],
+            "obstacle-table-corner-right_origin": [],
+            "obstacle-table_origin": [],
+            "right-arm": [
+                -0.15657533705234528,
+                -1.1719306707382202,
+                -0.3448139429092407,
+                5.54427433013916,
+                1.6133527755737305,
+                -1.3141133785247805
+            ],
+            "right-arm_origin": [],
+            "right-cam": [],
+            "right-cam_origin": [],
+            "right-gripper": [],
+            "right-gripper_origin": []
+        }
+    },
+    "world_state": {},
+    "constraints": {
+        "linear_constraints": [],
+        "pseudolinear_constraints": [],
+        "orientation_constraints": [],
+        "collision_specifications": []
+    },
+    "planner_options": {
+        "goal_metric_type": "squared_norm",
+        "max_ik_solutions": 100,
+        "min_ik_score": 0.01,
+        "resolution": 2,
+        "timeout": 300,
+        "goal_threshold": 0.1,
+        "frame_step": 0.01,
+        "input_ident_dist": 0.0001,
+        "iter_before_rand": 50,
+        "position_seeds": 0,
+        "return_partial_plan": false,
+        "configuration_distance_metric": "fs_config_l2",
+        "collision_buffer_mm": 1e-8,
+        "rseed": 0,
+        "meshes_as_octrees": false,
+        "collect_solution_diagnostics": false
+    }
+}{
+    "path": [
+        {
+            "cam-left-cup-crop": {
+                "referenceFrame": "world",
+                "pose": {
+                    "oZ": 1
+                }
+            },
+            "cam-left-cup-crop_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "oZ": 1
+                }
+            },
+            "cam-merged-cup": {
+                "referenceFrame": "world",
+                "pose": {
+                    "oZ": 1
+                }
+            },
+            "cam-merged-cup_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "oZ": 1
+                }
+            },
+            "left-arm": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 237.70400251792935,
+                    "y": 293.10735901786614,
+                    "z": 94.04677059230342,
+                    "oX": 0.9999999939338193,
+                    "oY": -0.000023052894445874885,
+                    "oZ": -0.000107707590411251,
+                    "theta": -179.99642463846914
+                }
+            },
+            "left-arm_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "oZ": 1,
+                    "theta": -29.999999999999996
+                }
+            },
+            "left-cam": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 272.7134258842924,
+                    "y": 328.10155974391705,
+                    "z": 174.04518427094828,
+                    "oX": 0.9995286276317766,
+                    "oY": 0.0035168538017092965,
+                    "oZ": -0.030498430842825858,
+                    "theta": -91.08423382659255
+                }
+            },
+            "left-cam_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 272.7134258842924,
+                    "y": 328.10155974391705,
+                    "z": 174.04518427094828,
+                    "oX": 0.9995286276317766,
+                    "oY": 0.0035168538017092965,
+                    "oZ": -0.030498430842825858,
+                    "theta": -91.08423382659255
+                }
+            },
+            "left-gripper": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 387.7040016080022,
+                    "y": 293.1039010836993,
+                    "z": 94.03061445374169,
+                    "oX": 0.9999999939338193,
+                    "oY": -0.000023052894445874885,
+                    "oZ": -0.000107707590411251,
+                    "theta": -179.99642463846914
+                }
+            },
+            "left-gripper_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 387.7040016080022,
+                    "y": 293.1039010836993,
+                    "z": 94.03061445374169,
+                    "oX": 0.9999999939338193,
+                    "oY": -0.000023052894445874885,
+                    "oZ": -0.000107707590411251,
+                    "theta": -179.99642463846914
+                }
+            },
+            "obstacle-arm-left-cord": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 227.70215780933628,
+                    "y": 213.10758972384002,
+                    "z": 94.04285552167977,
+                    "oX": 0.9999999939338193,
+                    "oY": -0.000023052894445874885,
+                    "oZ": -0.000107707590411251,
+                    "theta": -179.99642463846914
+                }
+            },
+            "obstacle-arm-left-cord_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 227.70215780933628,
+                    "y": 213.10758972384002,
+                    "z": 94.04285552167977,
+                    "oX": 0.9999999939338193,
+                    "oY": -0.000023052894445874885,
+                    "oZ": -0.000107707590411251,
+                    "theta": -179.99642463846914
+                }
+            },
+            "obstacle-back-wall": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": -180,
+                    "y": 412,
+                    "z": 40,
+                    "oZ": 1
+                }
+            },
+            "obstacle-back-wall_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": -180,
+                    "y": 412,
+                    "z": 40,
+                    "oZ": 1
+                }
+            },
+            "obstacle-ceiling": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 162,
+                    "y": 412,
+                    "z": 1000,
+                    "oZ": 1
+                }
+            },
+            "obstacle-ceiling_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 162,
+                    "y": 412,
+                    "z": 1000,
+                    "oZ": 1
+                }
+            },
+            "obstacle-front-wall": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 1122,
+                    "y": 412,
+                    "z": 500,
+                    "oZ": 1
+                }
+            },
+            "obstacle-front-wall_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 1122,
+                    "y": 412,
+                    "z": 500,
+                    "oZ": 1
+                }
+            },
+            "obstacle-left-monitor": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 300,
+                    "y": -260,
+                    "z": 150,
+                    "oZ": 1
+                }
+            },
+            "obstacle-left-monitor_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 300,
+                    "y": -260,
+                    "z": 150,
+                    "oZ": 1
+                }
+            },
+            "obstacle-left-wall": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 162,
+                    "y": -90,
+                    "z": 40,
+                    "oZ": 1
+                }
+            },
+            "obstacle-left-wall_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 162,
+                    "y": -90,
+                    "z": 40,
+                    "oZ": 1
+                }
+            },
+            "obstacle-right-bottle": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": -100,
+                    "y": 500,
+                    "z": 160,
+                    "oZ": 1
+                }
+            },
+            "obstacle-right-bottle_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": -100,
+                    "y": 500,
+                    "z": 160,
+                    "oZ": 1
+                }
+            },
+            "obstacle-right-wall": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 162,
+                    "y": 920,
+                    "z": 40,
+                    "oZ": 1
+                }
+            },
+            "obstacle-right-wall_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 162,
+                    "y": 920,
+                    "z": 40,
+                    "oZ": 1
+                }
+            },
+            "obstacle-table": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 162,
+                    "y": 412,
+                    "oZ": 1
+                }
+            },
+            "obstacle-table-corner-left": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 514,
+                    "y": -109.99999999999997,
+                    "z": 40,
+                    "oZ": 1,
+                    "theta": 45.00000000000001
+                }
+            },
+            "obstacle-table-corner-left_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 514,
+                    "y": -109.99999999999997,
+                    "z": 40,
+                    "oZ": 1,
+                    "theta": 45.00000000000001
+                }
+            },
+            "obstacle-table-corner-right": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 514,
+                    "y": 940,
+                    "z": 40,
+                    "oZ": 1,
+                    "theta": 45.00000000000001
+                }
+            },
+            "obstacle-table-corner-right_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 514,
+                    "y": 940,
+                    "z": 40,
+                    "oZ": 1,
+                    "theta": 45.00000000000001
+                }
+            },
+            "obstacle-table_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 162,
+                    "y": 412,
+                    "oZ": 1
+                }
+            },
+            "right-arm": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 180.21153286661155,
+                    "y": 823.9444502808212,
+                    "z": 407.8767406735934,
+                    "oX": 0.16455865857205068,
+                    "oY": -0.6576213796855187,
+                    "oZ": -0.7351561527114364,
+                    "theta": -172.52857166889763
+                }
+            },
+            "right-arm_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": -5,
+                    "y": 825.0000000000002,
+                    "oZ": 1,
+                    "theta": 29.999999999999996
+                }
+            },
+            "right-cam": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 224.51216233737188,
+                    "y": 747.0118857025875,
+                    "z": 439.0028508692201,
+                    "oX": 0.1664228750641789,
+                    "oY": -0.634340905366668,
+                    "oZ": -0.754927176907791,
+                    "theta": -83.13379859582119
+                }
+            },
+            "right-cam_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 224.51216233737188,
+                    "y": 747.0118857025875,
+                    "z": 439.0028508692201,
+                    "oX": 0.1664228750641789,
+                    "oY": -0.634340905366668,
+                    "oZ": -0.754927176907791,
+                    "theta": -83.13379859582119
+                }
+            },
+            "right-gripper": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 204.89533165241917,
+                    "y": 725.3012433279932,
+                    "z": 297.60331776687804,
+                    "oX": 0.16455865857205068,
+                    "oY": -0.6576213796855187,
+                    "oZ": -0.7351561527114364,
+                    "theta": -172.52857166889763
+                }
+            },
+            "right-gripper_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 204.89533165241917,
+                    "y": 725.3012433279932,
+                    "z": 297.60331776687804,
+                    "oX": 0.16455865857205068,
+                    "oY": -0.6576213796855187,
+                    "oZ": -0.7351561527114364,
+                    "theta": -172.52857166889763
+                }
+            }
+        },
+        {
+            "cam-left-cup-crop": {
+                "referenceFrame": "world",
+                "pose": {
+                    "oZ": 1
+                }
+            },
+            "cam-left-cup-crop_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "oZ": 1
+                }
+            },
+            "cam-merged-cup": {
+                "referenceFrame": "world",
+                "pose": {
+                    "oZ": 1
+                }
+            },
+            "cam-merged-cup_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "oZ": 1
+                }
+            },
+            "left-arm": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 237.7035390271891,
+                    "y": 293.10726622412386,
+                    "z": 84.01612015474551,
+                    "oX": 0.9999999939865207,
+                    "oY": -0.000018247674145419938,
+                    "oZ": -0.0001081387101087922,
+                    "theta": -179.99662165155476
+                }
+            },
+            "left-arm_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "oZ": 1,
+                    "theta": -29.999999999999996
+                }
+            },
+            "left-cam": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 272.7128287191993,
+                    "y": 328.10191026657026,
+                    "z": 164.0143984087391,
+                    "oX": 0.9995285975691894,
+                    "oY": 0.0035215522576820257,
+                    "oZ": -0.03049887393111661,
+                    "theta": -91.08443084259227
+                }
+            },
+            "left-cam_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 272.7128287191993,
+                    "y": 328.10191026657026,
+                    "z": 164.0143984087391,
+                    "oX": 0.9995285975691894,
+                    "oY": 0.0035215522576820257,
+                    "oZ": -0.03049887393111661,
+                    "theta": -91.08443084259227
+                }
+            },
+            "left-gripper": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 387.70353812516714,
+                    "y": 293.10452907300197,
+                    "z": 83.99989934822918,
+                    "oX": 0.9999999939865207,
+                    "oY": -0.000018247674145419938,
+                    "oZ": -0.0001081387101087922,
+                    "theta": -179.99662165155476
+                }
+            },
+            "left-gripper_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 387.70353812516714,
+                    "y": 293.10452907300197,
+                    "z": 83.99989934822918,
+                    "oX": 0.9999999939865207,
+                    "oY": -0.000018247674145419938,
+                    "oZ": -0.0001081387101087922,
+                    "theta": -179.99662165155476
+                }
+            },
+            "obstacle-arm-left-cord": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 227.70207876328897,
+                    "y": 213.10744885326056,
+                    "z": 84.01248447745013,
+                    "oX": 0.9999999939865207,
+                    "oY": -0.000018247674145419938,
+                    "oZ": -0.0001081387101087922,
+                    "theta": -179.99662165155476
+                }
+            },
+            "obstacle-arm-left-cord_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 227.70207876328897,
+                    "y": 213.10744885326056,
+                    "z": 84.01248447745013,
+                    "oX": 0.9999999939865207,
+                    "oY": -0.000018247674145419938,
+                    "oZ": -0.0001081387101087922,
+                    "theta": -179.99662165155476
+                }
+            },
+            "obstacle-back-wall": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": -180,
+                    "y": 412,
+                    "z": 40,
+                    "oZ": 1
+                }
+            },
+            "obstacle-back-wall_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": -180,
+                    "y": 412,
+                    "z": 40,
+                    "oZ": 1
+                }
+            },
+            "obstacle-ceiling": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 162,
+                    "y": 412,
+                    "z": 1000,
+                    "oZ": 1
+                }
+            },
+            "obstacle-ceiling_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 162,
+                    "y": 412,
+                    "z": 1000,
+                    "oZ": 1
+                }
+            },
+            "obstacle-front-wall": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 1122,
+                    "y": 412,
+                    "z": 500,
+                    "oZ": 1
+                }
+            },
+            "obstacle-front-wall_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 1122,
+                    "y": 412,
+                    "z": 500,
+                    "oZ": 1
+                }
+            },
+            "obstacle-left-monitor": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 300,
+                    "y": -260,
+                    "z": 150,
+                    "oZ": 1
+                }
+            },
+            "obstacle-left-monitor_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 300,
+                    "y": -260,
+                    "z": 150,
+                    "oZ": 1
+                }
+            },
+            "obstacle-left-wall": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 162,
+                    "y": -90,
+                    "z": 40,
+                    "oZ": 1
+                }
+            },
+            "obstacle-left-wall_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 162,
+                    "y": -90,
+                    "z": 40,
+                    "oZ": 1
+                }
+            },
+            "obstacle-right-bottle": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": -100,
+                    "y": 500,
+                    "z": 160,
+                    "oZ": 1
+                }
+            },
+            "obstacle-right-bottle_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": -100,
+                    "y": 500,
+                    "z": 160,
+                    "oZ": 1
+                }
+            },
+            "obstacle-right-wall": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 162,
+                    "y": 920,
+                    "z": 40,
+                    "oZ": 1
+                }
+            },
+            "obstacle-right-wall_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 162,
+                    "y": 920,
+                    "z": 40,
+                    "oZ": 1
+                }
+            },
+            "obstacle-table": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 162,
+                    "y": 412,
+                    "oZ": 1
+                }
+            },
+            "obstacle-table-corner-left": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 514,
+                    "y": -109.99999999999997,
+                    "z": 40,
+                    "oZ": 1,
+                    "theta": 45.00000000000001
+                }
+            },
+            "obstacle-table-corner-left_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 514,
+                    "y": -109.99999999999997,
+                    "z": 40,
+                    "oZ": 1,
+                    "theta": 45.00000000000001
+                }
+            },
+            "obstacle-table-corner-right": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 514,
+                    "y": 940,
+                    "z": 40,
+                    "oZ": 1,
+                    "theta": 45.00000000000001
+                }
+            },
+            "obstacle-table-corner-right_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 514,
+                    "y": 940,
+                    "z": 40,
+                    "oZ": 1,
+                    "theta": 45.00000000000001
+                }
+            },
+            "obstacle-table_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 162,
+                    "y": 412,
+                    "oZ": 1
+                }
+            },
+            "right-arm": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 180.21153286661155,
+                    "y": 823.9444502808212,
+                    "z": 407.8767406735934,
+                    "oX": 0.16455865857205068,
+                    "oY": -0.6576213796855187,
+                    "oZ": -0.7351561527114364,
+                    "theta": -172.52857166889763
+                }
+            },
+            "right-arm_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": -5,
+                    "y": 825.0000000000002,
+                    "oZ": 1,
+                    "theta": 29.999999999999996
+                }
+            },
+            "right-cam": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 224.51216233737188,
+                    "y": 747.0118857025875,
+                    "z": 439.0028508692201,
+                    "oX": 0.1664228750641789,
+                    "oY": -0.634340905366668,
+                    "oZ": -0.754927176907791,
+                    "theta": -83.13379859582119
+                }
+            },
+            "right-cam_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 224.51216233737188,
+                    "y": 747.0118857025875,
+                    "z": 439.0028508692201,
+                    "oX": 0.1664228750641789,
+                    "oY": -0.634340905366668,
+                    "oZ": -0.754927176907791,
+                    "theta": -83.13379859582119
+                }
+            },
+            "right-gripper": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 204.89533165241917,
+                    "y": 725.3012433279932,
+                    "z": 297.60331776687804,
+                    "oX": 0.16455865857205068,
+                    "oY": -0.6576213796855187,
+                    "oZ": -0.7351561527114364,
+                    "theta": -172.52857166889763
+                }
+            },
+            "right-gripper_origin": {
+                "referenceFrame": "world",
+                "pose": {
+                    "x": 204.89533165241917,
+                    "y": 725.3012433279932,
+                    "z": 297.60331776687804,
+                    "oX": 0.16455865857205068,
+                    "oY": -0.6576213796855187,
+                    "oZ": -0.7351561527114364,
+                    "theta": -172.52857166889763
+                }
+            }
+        }
+    ],
+    "trajectory": [
+        {
+            "cam-left-cup-crop": [],
+            "cam-left-cup-crop_origin": [],
+            "cam-merged-cup": [],
+            "cam-merged-cup_origin": [],
+            "left-arm": [
+                -4.652278900146484,
+                0.48613590002059937,
+                -0.6567204594612123,
+                4.2547607421875,
+                1.4947261810302734,
+                -0.1528232991695404
+            ],
+            "left-arm_origin": [],
+            "left-cam": [],
+            "left-cam_origin": [],
+            "left-gripper": [],
+            "left-gripper_origin": [],
+            "obstacle-arm-left-cord": [],
+            "obstacle-arm-left-cord_origin": [],
+            "obstacle-back-wall": [],
+            "obstacle-back-wall_origin": [],
+            "obstacle-ceiling": [],
+            "obstacle-ceiling_origin": [],
+            "obstacle-front-wall": [],
+            "obstacle-front-wall_origin": [],
+            "obstacle-left-monitor": [],
+            "obstacle-left-monitor_origin": [],
+            "obstacle-left-wall": [],
+            "obstacle-left-wall_origin": [],
+            "obstacle-right-bottle": [],
+            "obstacle-right-bottle_origin": [],
+            "obstacle-right-wall": [],
+            "obstacle-right-wall_origin": [],
+            "obstacle-table": [],
+            "obstacle-table-corner-left": [],
+            "obstacle-table-corner-left_origin": [],
+            "obstacle-table-corner-right": [],
+            "obstacle-table-corner-right_origin": [],
+            "obstacle-table_origin": [],
+            "right-arm": [
+                -0.15657533705234528,
+                -1.1719306707382202,
+                -0.3448139429092407,
+                5.54427433013916,
+                1.6133527755737305,
+                -1.3141133785247805
+            ],
+            "right-arm_origin": [],
+            "right-cam": [],
+            "right-cam_origin": [],
+            "right-gripper": [],
+            "right-gripper_origin": []
+        },
+        {
+            "cam-left-cup-crop": [],
+            "cam-left-cup-crop_origin": [],
+            "cam-merged-cup": [],
+            "cam-merged-cup_origin": [],
+            "left-arm": [
+                -4.650205872778848,
+                0.5238781313229136,
+                -0.6726434104019521,
+                4.255418714294777,
+                1.5046549124529396,
+                -0.13334548724556775
+            ],
+            "left-arm_origin": [],
+            "left-cam": [],
+            "left-cam_origin": [],
+            "left-gripper": [],
+            "left-gripper_origin": [],
+            "obstacle-arm-left-cord": [],
+            "obstacle-arm-left-cord_origin": [],
+            "obstacle-back-wall": [],
+            "obstacle-back-wall_origin": [],
+            "obstacle-ceiling": [],
+            "obstacle-ceiling_origin": [],
+            "obstacle-front-wall": [],
+            "obstacle-front-wall_origin": [],
+            "obstacle-left-monitor": [],
+            "obstacle-left-monitor_origin": [],
+            "obstacle-left-wall": [],
+            "obstacle-left-wall_origin": [],
+            "obstacle-right-bottle": [],
+            "obstacle-right-bottle_origin": [],
+            "obstacle-right-wall": [],
+            "obstacle-right-wall_origin": [],
+            "obstacle-table": [],
+            "obstacle-table-corner-left": [],
+            "obstacle-table-corner-left_origin": [],
+            "obstacle-table-corner-right": [],
+            "obstacle-table-corner-right_origin": [],
+            "obstacle-table_origin": [],
+            "right-arm": [
+                -0.15657533705234528,
+                -1.1719306707382202,
+                -0.3448139429092407,
+                5.54427433013916,
+                1.6133527755737305,
+                -1.3141133785247805
+            ],
+            "right-arm_origin": [],
+            "right-cam": [],
+            "right-cam_origin": [],
+            "right-gripper": [],
+            "right-gripper_origin": []
+        }
+    ]
+}

--- a/src/lib/plugins/MotionPlanReplayer/__tests__/parse-plan.spec.ts
+++ b/src/lib/plugins/MotionPlanReplayer/__tests__/parse-plan.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { parsePlan, PlanParseError } from '../parse-plan'
+import capturedPlan from './__fixtures__/plan.json?raw'
 
 const MINIMAL_FRAME_SYSTEM = {
 	frames: {
@@ -50,5 +51,47 @@ describe('parsePlan', () => {
 		expect(() =>
 			parsePlan(JSON.stringify({ frame_system: MINIMAL_FRAME_SYSTEM, trajectory: 'bad' }))
 		).toThrow(PlanParseError)
+	})
+})
+
+/**
+ * `plan.json` is an unmodified capture of a two-armed rig lowering to a cup —
+ * the same file a user drags into the tool. It is deliberately not touched up,
+ * so these assertions describe what real plans actually contain.
+ */
+describe('parsePlan with a captured plan', () => {
+	const plan = parsePlan(capturedPlan)
+
+	it('reads the frame system and the trajectory from the two concatenated objects', () => {
+		expect(Object.keys(plan.frames)).toHaveLength(79)
+		expect(Object.keys(plan.parents)).toHaveLength(79)
+		expect(plan.goals).toHaveLength(1)
+		expect(plan.trajectory).toHaveLength(2)
+	})
+
+	it('keeps every frame type the planner emits', () => {
+		const counts: Record<string, number> = {}
+		for (const { frame_type } of Object.values(plan.frames)) {
+			counts[frame_type] = (counts[frame_type] ?? 0) + 1
+		}
+
+		expect(counts).toEqual({ static: 4, tail_geometry_static: 19, model: 15, named: 41 })
+	})
+
+	it('keeps the empty joint arrays that static frames carry in every step', () => {
+		const step = plan.trajectory[0]!
+		const moving = Object.entries(step).filter(([, joints]) => joints.length > 0)
+
+		// Only the two arms actually articulate; the other 36 frames ride along
+		// with an empty array, which is the shape the descriptor builder relies on.
+		expect(Object.keys(step)).toHaveLength(38)
+		expect(moving.map(([name]) => name)).toEqual(['left-arm', 'right-arm'])
+		expect(step['left-arm']).toHaveLength(6)
+	})
+
+	it('ignores the planner keys the replayer does not read', () => {
+		// world_state, constraints, planner_options, start_state and path are all
+		// present in the capture; parsing must not reject them.
+		expect(plan.frames['obstacle-table']).toBeDefined()
 	})
 })

--- a/src/lib/plugins/MotionPlanReplayer/__tests__/parse-plan.spec.ts
+++ b/src/lib/plugins/MotionPlanReplayer/__tests__/parse-plan.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import { parsePlan, PlanParseError } from '../parse-plan'
+
+const MINIMAL_FRAME_SYSTEM = {
+	frames: {
+		'left-arm': {
+			frame_type: 'model',
+			frame: { name: 'left-arm', model: { joints: [{ id: 'waist' }] } },
+		},
+		'left-arm:waist': {
+			frame_type: 'named',
+			frame: {
+				inner_frame: {
+					frame_type: 'rotational',
+					frame: { axis: { X: 0, Y: 0, Z: 1 } },
+				},
+			},
+		},
+	},
+	parents: { 'left-arm:waist': 'world' },
+}
+
+const REQUEST_OBJ = { frame_system: MINIMAL_FRAME_SYSTEM, goals: [], start_state: {} }
+const RESULT_OBJ = { trajectory: [{ 'left-arm': [0.5] }] }
+
+describe('parsePlan', () => {
+	it('parses a single-object plan (no trajectory)', () => {
+		const plan = parsePlan(JSON.stringify(REQUEST_OBJ))
+		expect(Object.keys(plan.frames)).toContain('left-arm:waist')
+		expect(plan.trajectory).toHaveLength(0)
+	})
+
+	it('parses two concatenated JSON objects', () => {
+		const content = JSON.stringify(REQUEST_OBJ) + JSON.stringify(RESULT_OBJ)
+		const plan = parsePlan(content)
+		expect(plan.trajectory).toHaveLength(1)
+		expect(plan.trajectory[0]!['left-arm']).toEqual([0.5])
+	})
+
+	it('throws PlanParseError when frame_system is absent', () => {
+		expect(() => parsePlan(JSON.stringify({ path: [], trajectory: [] }))).toThrow(PlanParseError)
+	})
+
+	it('throws PlanParseError on invalid JSON', () => {
+		expect(() => parsePlan('{ not valid json')).toThrow(PlanParseError)
+	})
+
+	it('throws PlanParseError when a chunk has wrong types', () => {
+		expect(() =>
+			parsePlan(JSON.stringify({ frame_system: MINIMAL_FRAME_SYSTEM, trajectory: 'bad' }))
+		).toThrow(PlanParseError)
+	})
+})

--- a/src/lib/plugins/MotionPlanReplayer/parse-plan.ts
+++ b/src/lib/plugins/MotionPlanReplayer/parse-plan.ts
@@ -1,0 +1,136 @@
+import { z } from 'zod'
+
+const RawFrameSchema = z.object({
+	frame_type: z.string(),
+	frame: z.unknown(),
+})
+
+const FrameSystemSchema = z.object({
+	frames: z.record(z.string(), RawFrameSchema),
+	parents: z.record(z.string(), z.string()),
+})
+
+const PlanChunkSchema = z.object({
+	frame_system: FrameSystemSchema.optional(),
+	goals: z.array(z.unknown()).optional(),
+	trajectory: z.array(z.record(z.string(), z.array(z.number()))).optional(),
+})
+
+export type RawFrame = z.infer<typeof RawFrameSchema>
+
+export type ParsedPlan = {
+	frames: Record<string, RawFrame>
+	parents: Record<string, string>
+	trajectory: Array<Record<string, number[]>>
+	goals: unknown[]
+}
+
+export class PlanParseError extends Error {
+	constructor(message: string) {
+		super(message)
+		this.name = 'PlanParseError'
+	}
+}
+
+const skipWhitespace = (text: string, start: number): number => {
+	let i = start
+	while (i < text.length && /\s/.test(text[i]!)) i++
+	return i
+}
+
+const readJSONObject = (text: string, start: number): { raw: string; end: number } | null => {
+	let i = skipWhitespace(text, start)
+	if (i >= text.length || text[i] !== '{') return null
+	let depth = 0
+	let inString = false
+	let escaped = false
+	for (; i < text.length; i++) {
+		const ch = text[i]!
+		if (inString) {
+			if (escaped) {
+				escaped = false
+				continue
+			}
+			if (ch === '\\') {
+				escaped = true
+				continue
+			}
+			if (ch === '"') inString = false
+			continue
+		}
+		if (ch === '"') {
+			inString = true
+			continue
+		}
+		if (ch === '{') {
+			depth++
+			continue
+		}
+		if (ch === '}') {
+			depth--
+			if (depth === 0) return { raw: text.slice(start, i + 1), end: i + 1 }
+		}
+	}
+	return null
+}
+
+const splitJsonObjects = (content: string): string[] => {
+	const chunks: string[] = []
+	let index = 0
+	for (let i = 0; i < 8; i++) {
+		index = skipWhitespace(content, index)
+		if (index >= content.length) break
+		const next = readJSONObject(content, index)
+		if (!next) break
+		chunks.push(next.raw)
+		index = next.end
+	}
+	return chunks
+}
+
+const parseChunk = (raw: string): z.infer<typeof PlanChunkSchema> => {
+	let parsed: unknown
+	try {
+		parsed = JSON.parse(raw)
+	} catch {
+		throw new PlanParseError('plan JSON contains invalid JSON')
+	}
+
+	const result = PlanChunkSchema.safeParse(parsed)
+	if (!result.success) {
+		throw new PlanParseError('plan JSON does not match expected motion plan format')
+	}
+	return result.data
+}
+
+export const parsePlan = (content: string): ParsedPlan => {
+	const chunks = splitJsonObjects(content)
+	if (chunks.length === 0) {
+		throw new PlanParseError('plan JSON contains invalid JSON')
+	}
+
+	let frames: Record<string, RawFrame> = {}
+	let parents: Record<string, string> = {}
+	let trajectory: Array<Record<string, number[]>> = []
+	let goals: unknown[] = []
+	let foundFrameSystem = false
+
+	for (const chunk of chunks) {
+		const obj = parseChunk(chunk)
+
+		if (obj.frame_system) {
+			frames = obj.frame_system.frames
+			parents = obj.frame_system.parents
+			goals = obj.goals ?? []
+			foundFrameSystem = true
+		}
+
+		if (obj.trajectory) {
+			trajectory = obj.trajectory
+		}
+	}
+
+	if (!foundFrameSystem) throw new PlanParseError('plan is missing frame_system')
+
+	return { frames, parents, trajectory, goals }
+}

--- a/src/lib/plugins/MotionPlanReplayer/parse-plan.ts
+++ b/src/lib/plugins/MotionPlanReplayer/parse-plan.ts
@@ -18,13 +18,6 @@ const PlanChunkSchema = z.object({
 
 export type RawFrame = z.infer<typeof RawFrameSchema>
 
-export type ParsedPlan = {
-	frames: Record<string, RawFrame>
-	parents: Record<string, string>
-	trajectory: Array<Record<string, number[]>>
-	goals: unknown[]
-}
-
 export class PlanParseError extends Error {
 	constructor(message: string) {
 		super(message)
@@ -88,49 +81,58 @@ const splitJsonObjects = (content: string): string[] => {
 	return chunks
 }
 
-const parseChunk = (raw: string): z.infer<typeof PlanChunkSchema> => {
-	let parsed: unknown
-	try {
-		parsed = JSON.parse(raw)
-	} catch {
-		throw new PlanParseError('plan JSON contains invalid JSON')
-	}
+const PlanSchema = z
+	.string()
+	// A plan file is one or more JSON objects concatenated with no separator, so
+	// split it before anything can be handed to JSON.parse.
+	.transform(splitJsonObjects)
+	.pipe(z.array(z.string()).min(1, 'plan JSON contains invalid JSON'))
+	.transform((chunks, ctx) => {
+		try {
+			return chunks.map((raw) => JSON.parse(raw) as unknown)
+		} catch {
+			ctx.addIssue({ code: 'custom', message: 'plan JSON contains invalid JSON' })
+			return z.NEVER
+		}
+	})
+	.pipe(z.array(PlanChunkSchema))
+	.transform((chunks, ctx) => {
+		let frames: Record<string, RawFrame> = {}
+		let parents: Record<string, string> = {}
+		let trajectory: Array<Record<string, number[]>> = []
+		let goals: unknown[] = []
+		let foundFrameSystem = false
 
-	const result = PlanChunkSchema.safeParse(parsed)
-	if (!result.success) {
-		throw new PlanParseError('plan JSON does not match expected motion plan format')
-	}
-	return result.data
-}
+		for (const chunk of chunks) {
+			if (chunk.frame_system) {
+				frames = chunk.frame_system.frames
+				parents = chunk.frame_system.parents
+				goals = chunk.goals ?? []
+				foundFrameSystem = true
+			}
+
+			if (chunk.trajectory) {
+				trajectory = chunk.trajectory
+			}
+		}
+
+		if (!foundFrameSystem) {
+			ctx.addIssue({ code: 'custom', message: 'plan is missing frame_system' })
+			return z.NEVER
+		}
+
+		return { frames, parents, trajectory, goals }
+	})
+
+export type ParsedPlan = z.infer<typeof PlanSchema>
 
 export const parsePlan = (content: string): ParsedPlan => {
-	const chunks = splitJsonObjects(content)
-	if (chunks.length === 0) {
-		throw new PlanParseError('plan JSON contains invalid JSON')
-	}
+	const result = PlanSchema.safeParse(content)
+	if (result.success) return result.data
 
-	let frames: Record<string, RawFrame> = {}
-	let parents: Record<string, string> = {}
-	let trajectory: Array<Record<string, number[]>> = []
-	let goals: unknown[] = []
-	let foundFrameSystem = false
-
-	for (const chunk of chunks) {
-		const obj = parseChunk(chunk)
-
-		if (obj.frame_system) {
-			frames = obj.frame_system.frames
-			parents = obj.frame_system.parents
-			goals = obj.goals ?? []
-			foundFrameSystem = true
-		}
-
-		if (obj.trajectory) {
-			trajectory = obj.trajectory
-		}
-	}
-
-	if (!foundFrameSystem) throw new PlanParseError('plan is missing frame_system')
-
-	return { frames, parents, trajectory, goals }
+	const issue = result.error.issues[0]
+	const path = issue?.path.join('.')
+	throw new PlanParseError(
+		path ? `${issue!.message} (at ${path})` : (issue?.message ?? 'plan JSON is invalid')
+	)
 }


### PR DESCRIPTION
The Motion Plan Replayer needs raw plan JSON turned into a typed, validated structure before anything can be rendered. Adds parsePlan, which parses a plan's concatenated JSON objects into a ParsedPlan (frames, parents, trajectory, goals) with zod validation and a typed PlanParseError.

## Changes
- Frontend: Adds parse-plan.ts — zod schemas + brace-matching splitter for multi-object plan JSON; exports parsePlan, ParsedPlan, RawFrame, PlanParseError
- Tests: Adds parse-plan.spec.ts covering valid plans, malformed JSON, and missing fields

## Stack
- PR #838 
- PR #839 
- PR #840 
- PR #841 
- PR #842
- PR #843
- PR #844

## Links
- [APP-9316](https://viam.atlassian.net/browse/APP-9316)

## Testing
- Run npx vitest run src/lib/plugins/MotionPlanReplayer/__tests__/parse-plan.spec.ts
- Confirm valid multi-object plan JSON parses into a ParsedPlan; malformed input throws PlanParseError with a readable message

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

[APP-9316]: https://viam.atlassian.net/browse/APP-9316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ