### PR TITLE
Add frame-descriptor derivation for motion plans

### DIFF
--- a/.changeset/motion-plan-replayer-1b-descriptors.md
+++ b/.changeset/motion-plan-replayer-1b-descriptors.md
@@ -1,0 +1,5 @@
+---
+'@viamrobotics/motion-tools': patch
+---
+
+Add frame-descriptor derivation for the Motion Plan Replayer: converts a `ParsedPlan` into static and jointed `FrameDescriptor`s (geometry, orientation conversion, joint-index mapping, end-effector reparenting).

--- a/src/lib/plugins/MotionPlanReplayer/__tests__/build-frame-descriptors.spec.ts
+++ b/src/lib/plugins/MotionPlanReplayer/__tests__/build-frame-descriptors.spec.ts
@@ -1,0 +1,500 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ParsedPlan } from '../parse-plan'
+
+import { buildFrameDescriptors } from '../build-frame-descriptors'
+
+const plan = (frames: ParsedPlan['frames'], parents: ParsedPlan['parents']): ParsedPlan => ({
+	frames,
+	parents,
+	trajectory: [],
+	goals: [],
+})
+
+describe('buildFrameDescriptors', () => {
+	it('produces a static descriptor for a named static frame', () => {
+		const p = plan(
+			{
+				'arm:link': {
+					frame_type: 'named',
+					frame: {
+						inner_frame: {
+							frame_type: 'static',
+							frame: {
+								translation: { X: 0, Y: 0, Z: 267 },
+								orientation: { type: 'quaternion', value: { W: 1, X: 0, Y: 0, Z: 0 } },
+							},
+						},
+					},
+				},
+			},
+			{ 'arm:link': 'world' }
+		)
+		const descriptors = buildFrameDescriptors(p)
+		expect(descriptors).toHaveLength(1)
+		const d = descriptors[0]!
+		expect(d.kind).toBe('static')
+		if (d.kind === 'static') {
+			expect(d.name).toBe('arm:link')
+			expect(d.parent).toBe('world')
+			expect(d.localPose.z).toBeCloseTo(267)
+			expect(d.geometry).toBeNull()
+		}
+	})
+
+	it('joint frames emit joint descriptors; link frames emit static descriptors parented to their joint', () => {
+		// arm chain: arm:base (static) → arm:waist (joint, Z) → arm:base_top (static link)
+		//            arm:base_top → arm:shoulder (joint, Y) → arm:upper_arm (static link)
+		const p = plan(
+			{
+				arm: {
+					frame_type: 'model',
+					frame: { name: 'arm', model: { joints: [{ id: 'waist' }, { id: 'shoulder' }] } },
+				},
+				'arm:waist': {
+					frame_type: 'named',
+					frame: {
+						inner_frame: {
+							frame_type: 'rotational',
+							frame: { axis: { X: 0, Y: 0, Z: 1 } },
+						},
+					},
+				},
+				'arm:shoulder': {
+					frame_type: 'named',
+					frame: {
+						inner_frame: {
+							frame_type: 'rotational',
+							frame: { axis: { X: 0, Y: 1, Z: 0 } },
+						},
+					},
+				},
+				'arm:base_top': {
+					frame_type: 'named',
+					frame: {
+						inner_frame: {
+							frame_type: 'static',
+							frame: {
+								translation: { X: 0, Y: 0, Z: 267 },
+								orientation: { type: 'quaternion', value: { W: 1, X: 0, Y: 0, Z: 0 } },
+							},
+						},
+					},
+				},
+				'arm:upper_arm': {
+					frame_type: 'named',
+					frame: {
+						inner_frame: {
+							frame_type: 'static',
+							frame: {
+								translation: { X: 53.5, Y: 0, Z: 284.5 },
+								orientation: { type: 'quaternion', value: { W: 1, X: 0, Y: 0, Z: 0 } },
+							},
+						},
+					},
+				},
+			},
+			{
+				'arm:waist': 'arm:base',
+				'arm:shoulder': 'arm:base_top',
+				'arm:base_top': 'arm:waist',
+				'arm:upper_arm': 'arm:shoulder',
+			}
+		)
+		const descriptors = buildFrameDescriptors(p)
+
+		// Joint frames appear as joint descriptors
+		const waist = descriptors.find((d) => d.name === 'arm:waist')!
+		expect(waist).toBeDefined()
+		expect(waist.kind).toBe('joint')
+		if (waist.kind === 'joint') {
+			expect(waist.parent).toBe('arm:base')
+			expect(waist.componentName).toBe('arm')
+			expect(waist.jointIndex).toBe(0)
+			expect(waist.axis).toEqual({ X: 0, Y: 0, Z: 1 })
+		}
+
+		const shoulder = descriptors.find((d) => d.name === 'arm:shoulder')!
+		expect(shoulder).toBeDefined()
+		expect(shoulder.kind).toBe('joint')
+		if (shoulder.kind === 'joint') {
+			expect(shoulder.parent).toBe('arm:base_top')
+			expect(shoulder.componentName).toBe('arm')
+			expect(shoulder.jointIndex).toBe(1)
+			expect(shoulder.axis).toEqual({ X: 0, Y: 1, Z: 0 })
+		}
+
+		// Link frames appear as static descriptors parented directly to their joint
+		const baseTop = descriptors.find((d) => d.name === 'arm:base_top')!
+		expect(baseTop).toBeDefined()
+		expect(baseTop.kind).toBe('static')
+		if (baseTop.kind === 'static') {
+			expect(baseTop.parent).toBe('arm:waist') // parented to the joint, not the joint's parent
+			expect(baseTop.localPose.z).toBeCloseTo(267)
+		}
+
+		const upperArm = descriptors.find((d) => d.name === 'arm:upper_arm')!
+		expect(upperArm).toBeDefined()
+		expect(upperArm.kind).toBe('static')
+		if (upperArm.kind === 'static') {
+			expect(upperArm.parent).toBe('arm:shoulder')
+			expect(upperArm.localPose.x).toBeCloseTo(53.5)
+			expect(upperArm.localPose.z).toBeCloseTo(284.5)
+		}
+	})
+
+	it('prefers primary_output_frame over last-joint static child when both exist', () => {
+		const p = plan(
+			{
+				arm: {
+					frame_type: 'model',
+					frame: {
+						name: 'arm',
+						model: {
+							joints: [{ id: 'waist' }, { id: 'gripper_rot' }],
+							primary_output_frame: 'gripper_mount',
+							links: [{ id: 'extra_link' }, { id: 'gripper_mount' }],
+						},
+					},
+				},
+				'arm:gripper_rot': {
+					frame_type: 'named',
+					frame: {
+						inner_frame: { frame_type: 'rotational', frame: { axis: { X: 0, Y: 0, Z: 1 } } },
+					},
+				},
+				'arm:extra_link': {
+					frame_type: 'named',
+					frame: {
+						inner_frame: {
+							frame_type: 'static',
+							frame: {
+								translation: { X: 0, Y: 0, Z: 0 },
+								orientation: { type: 'quaternion', value: { W: 1, X: 0, Y: 0, Z: 0 } },
+							},
+						},
+					},
+				},
+				'arm:gripper_mount': {
+					frame_type: 'named',
+					frame: {
+						inner_frame: {
+							frame_type: 'static',
+							frame: {
+								translation: { X: 0, Y: 0, Z: 0 },
+								orientation: { type: 'quaternion', value: { W: 1, X: 0, Y: 0, Z: 0 } },
+							},
+						},
+					},
+				},
+				camera_origin: {
+					frame_type: 'static',
+					frame: {
+						translation: { X: 10, Y: 0, Z: 0 },
+						orientation: { type: 'quaternion', value: { W: 1, X: 0, Y: 0, Z: 0 } },
+					},
+				},
+			},
+			{
+				'arm:extra_link': 'arm:gripper_rot',
+				'arm:gripper_mount': 'arm:extra_link',
+				camera_origin: 'arm',
+			}
+		)
+		const camera = buildFrameDescriptors(p).find((d) => d.name === 'camera_origin')!
+		expect(camera.parent).toBe('arm:gripper_mount')
+	})
+
+	it('remaps frames parented to a model frame to the terminal static frame', () => {
+		// camera is parented to the model frame 'arm' (never an ECS entity).
+		// It should be reparented to 'arm:gripper_mount' (static frame after the last joint).
+		const p = plan(
+			{
+				arm: {
+					frame_type: 'model',
+					frame: { name: 'arm', model: { joints: [{ id: 'waist' }, { id: 'gripper_rot' }] } },
+				},
+				'arm:gripper_rot': {
+					frame_type: 'named',
+					frame: {
+						inner_frame: { frame_type: 'rotational', frame: { axis: { X: 0, Y: 0, Z: 1 } } },
+					},
+				},
+				'arm:gripper_mount': {
+					frame_type: 'named',
+					frame: {
+						inner_frame: {
+							frame_type: 'static',
+							frame: {
+								translation: { X: 0, Y: 0, Z: 0 },
+								orientation: { type: 'quaternion', value: { W: 1, X: 0, Y: 0, Z: 0 } },
+							},
+						},
+					},
+				},
+				camera_origin: {
+					frame_type: 'static',
+					frame: {
+						translation: { X: 10, Y: 0, Z: 0 },
+						orientation: { type: 'quaternion', value: { W: 1, X: 0, Y: 0, Z: 0 } },
+					},
+				},
+			},
+			{
+				'arm:gripper_mount': 'arm:gripper_rot',
+				camera_origin: 'arm', // model frame — should be remapped
+			}
+		)
+		const descriptors = buildFrameDescriptors(p)
+		const camera = descriptors.find((d) => d.name === 'camera_origin')!
+		expect(camera).toBeDefined()
+		expect(camera.parent).toBe('arm:gripper_mount') // remapped from 'arm'
+	})
+
+	it('skips model frames', () => {
+		const p = plan(
+			{ arm: { frame_type: 'model', frame: { name: 'arm', model: { joints: [] } } } },
+			{}
+		)
+		expect(buildFrameDescriptors(p)).toHaveLength(0)
+	})
+
+	it('parses capsule geometry from a static frame', () => {
+		const p = plan(
+			{
+				'arm:link': {
+					frame_type: 'named',
+					frame: {
+						inner_frame: {
+							frame_type: 'static',
+							frame: {
+								translation: { X: 0, Y: 0, Z: 0 },
+								orientation: { type: 'quaternion', value: { W: 1, X: 0, Y: 0, Z: 0 } },
+								geometry: {
+									type: 'capsule',
+									r: 50,
+									l: 320,
+									translation: { X: 0, Y: 0, Z: 160 },
+									orientation: { type: 'quaternion', value: { W: 1, X: 0, Y: 0, Z: 0 } },
+									Label: 'link',
+								},
+							},
+						},
+					},
+				},
+			},
+			{ 'arm:link': 'world' }
+		)
+		const descriptors = buildFrameDescriptors(p)
+		const d = descriptors[0]!
+		if (d.kind === 'static') {
+			expect(d.geometry).not.toBeNull()
+			expect(d.geometry!.geometryType.case).toBe('capsule')
+			if (d.geometry!.geometryType.case === 'capsule') {
+				expect(d.geometry!.geometryType.value.radiusMm).toBe(50)
+				expect(d.geometry!.geometryType.value.lengthMm).toBe(320)
+			}
+			expect(d.geometry!.center!.z).toBeCloseTo(160)
+		}
+	})
+
+	it('subtracts frame translation from parent-frame geometry center (xArm6 base_top)', () => {
+		const p = plan(
+			{
+				'arm:base_top': {
+					frame_type: 'named',
+					frame: {
+						inner_frame: {
+							frame_type: 'static',
+							frame: {
+								translation: { X: 0, Y: 0, Z: 267 },
+								orientation: { type: 'quaternion', value: { W: 1, X: 0, Y: 0, Z: 0 } },
+								geometry: {
+									type: 'capsule',
+									r: 50,
+									l: 320,
+									translation: { X: 0, Y: 0, Z: 160 },
+									orientation: { type: 'quaternion', value: { W: 1, X: 0, Y: 0, Z: 0 } },
+									Label: 'base_top',
+								},
+							},
+						},
+					},
+				},
+			},
+			{ 'arm:base_top': 'arm:waist' }
+		)
+		const d = buildFrameDescriptors(p)[0]!
+		if (d.kind === 'static') {
+			expect(d.localPose.z).toBeCloseTo(267)
+			// geo z=160 and frame z=267 both in parent (waist) → local center 107mm below frame
+			expect(d.geometry!.center!.z).toBeCloseTo(-107)
+		}
+	})
+
+	it('rotates parent-frame geometry offset into link-local coords (xArm850 link_2)', () => {
+		const p = plan(
+			{
+				'left-arm:link_2': {
+					frame_type: 'named',
+					frame: {
+						inner_frame: {
+							frame_type: 'static',
+							frame: {
+								translation: { X: 390, Y: 0, Z: 0 },
+								orientation: {
+									type: 'quaternion',
+									value: {
+										W: -2.5973434669646147e-6,
+										X: -0.7071054825064661,
+										Y: 0.7071080798547033,
+										Z: 2.597353007557415e-6,
+									},
+								},
+								geometry: {
+									type: 'box',
+									x: 500.07,
+									y: 119.987,
+									z: 161.805,
+									translation: { X: 189.857, Y: 0, Z: 31.0907 },
+									orientation: { type: 'quaternion', value: { W: 1, X: 0, Y: 0, Z: 0 } },
+									Label: 'link_2',
+								},
+							},
+						},
+					},
+				},
+			},
+			{ 'left-arm:link_2': 'left-arm:joint_2' }
+		)
+		const d = buildFrameDescriptors(p)[0]!
+		if (d.kind === 'static') {
+			expect(d.localPose.x).toBeCloseTo(390)
+			// R_frame⁻¹ * (geo − frame): not a naive component-wise subtract
+			expect(d.geometry!.center!.x).toBeCloseTo(0, 1)
+			expect(d.geometry!.center!.y).toBeCloseTo(200.143, 1)
+			expect(d.geometry!.center!.z).toBeCloseTo(-31.0907, 1)
+		}
+	})
+
+	it('parses euler_angles orientation on a static frame (not identity)', () => {
+		const p = plan(
+			{
+				'arm:link': {
+					frame_type: 'named',
+					frame: {
+						inner_frame: {
+							frame_type: 'static',
+							frame: {
+								translation: { X: 0, Y: 0, Z: 0 },
+								// 90 degree yaw about Z
+								orientation: {
+									type: 'euler_angles',
+									value: { roll: 0, pitch: 0, yaw: Math.PI / 2 },
+								},
+							},
+						},
+					},
+				},
+			},
+			{ 'arm:link': 'world' }
+		)
+		const d = buildFrameDescriptors(p)[0]!
+		if (d.kind === 'static') {
+			// Identity would be oX:0 oY:0 oZ:1 theta:0 — assert it's not identity and
+			// specifically a 90 degree rotation about Z.
+			expect(d.localPose.theta).toBeCloseTo(90)
+			expect(d.localPose.oZ).toBeCloseTo(1)
+		}
+	})
+
+	it('parses euler_angles on link frame and rotates geometry orient into local coords', () => {
+		// link_1 from salad: 90° fixed rotation with geometry offset in parent frame
+		const p = plan(
+			{
+				'left-arm:link_1': {
+					frame_type: 'named',
+					frame: {
+						inner_frame: {
+							frame_type: 'static',
+							frame: {
+								translation: { X: 0, Y: 0, Z: 0 },
+								orientation: {
+									type: 'euler_angles',
+									value: { roll: 1.5708, pitch: -1.5708, yaw: 0 },
+								},
+								geometry: {
+									type: 'box',
+									x: 120.619,
+									y: 185.133,
+									z: 238.5,
+									translation: { X: 0, Y: 32.5667, Z: -59.25 },
+									orientation: { type: 'quaternion', value: { W: 1, X: 0, Y: 0, Z: 0 } },
+									Label: 'link_1',
+								},
+							},
+						},
+					},
+				},
+			},
+			{ 'left-arm:link_1': 'left-arm:joint_1' }
+		)
+		const d = buildFrameDescriptors(p)[0]!
+		if (d.kind === 'static') {
+			expect(d.localPose.theta).not.toBeCloseTo(0)
+			// geometry center offset is rotated into link-local, not left in parent Y/Z
+			expect(d.geometry!.center!.x).toBeCloseTo(-59.25, 1)
+			expect(d.geometry!.center!.y).toBeCloseTo(0, 1)
+			expect(d.geometry!.center!.z).toBeCloseTo(-32.5667, 1)
+		}
+	})
+
+	it('parses ov_degrees orientation on a static frame', () => {
+		const p = plan(
+			{
+				'arm:link': {
+					frame_type: 'named',
+					frame: {
+						inner_frame: {
+							frame_type: 'static',
+							frame: {
+								translation: { X: 0, Y: 0, Z: 0 },
+								orientation: { type: 'ov_degrees', value: { x: 0, y: 0, z: 1, th: 90 } },
+							},
+						},
+					},
+				},
+			},
+			{ 'arm:link': 'world' }
+		)
+		const d = buildFrameDescriptors(p)[0]!
+		if (d.kind === 'static') {
+			expect(d.localPose.theta).toBeCloseTo(90)
+			expect(d.localPose.oZ).toBeCloseTo(1)
+		}
+	})
+
+	it('returns null geometry for unrecognized geometry type', () => {
+		const p = plan(
+			{
+				'arm:link': {
+					frame_type: 'named',
+					frame: {
+						inner_frame: {
+							frame_type: 'static',
+							frame: {
+								translation: { X: 0, Y: 0, Z: 0 },
+								orientation: { type: 'quaternion', value: { W: 1, X: 0, Y: 0, Z: 0 } },
+								geometry: { type: '', r: 1, l: 0 },
+							},
+						},
+					},
+				},
+			},
+			{ 'arm:link': 'world' }
+		)
+		const descriptors = buildFrameDescriptors(p)
+		const d = descriptors[0]!
+		if (d.kind === 'static') expect(d.geometry).toBeNull()
+	})
+})

--- a/src/lib/plugins/MotionPlanReplayer/build-frame-descriptors.ts
+++ b/src/lib/plugins/MotionPlanReplayer/build-frame-descriptors.ts
@@ -1,0 +1,334 @@
+import { Euler, MathUtils, Quaternion, Vector3 } from 'three'
+
+import {
+	Capsule,
+	Geometry,
+	Pose,
+	RectangularPrism,
+	Sphere,
+	Vector3 as ViamVector3,
+} from '$lib/buf/common/v1/common_pb'
+import { OrientationVector } from '$lib/three/OrientationVector'
+import { quaternionToPose } from '$lib/transform'
+
+import type { ParsedPlan } from './parse-plan'
+
+import { planUuid } from './plan-uuid'
+
+/** A rigid link with a fixed local transform — no joint involved. */
+export interface StaticFrameDescriptor {
+	kind: 'static'
+	name: string
+	parent: string
+	localPose: Pose
+	geometry: Geometry | null
+	uuid: Uint8Array<ArrayBuffer>
+}
+
+/** A revolute joint frame. Its pose at each step is a pure rotation around `axis` by the trajectory angle. */
+export interface JointFrameDescriptor {
+	kind: 'joint'
+	name: string
+	parent: string
+	axis: { X: number; Y: number; Z: number }
+	componentName: string
+	jointIndex: number
+	uuid: Uint8Array<ArrayBuffer>
+}
+
+export type FrameDescriptor = StaticFrameDescriptor | JointFrameDescriptor
+
+// Shared scratch objects — safe in single-threaded JS
+const tmpQ = new Quaternion()
+const tmpQFrame = new Quaternion()
+const tmpQGeo = new Quaternion()
+const tmpQInv = new Quaternion()
+const tmpQLocal = new Quaternion()
+const tmpE = new Euler()
+const tmpV = new Vector3()
+const tmpOv = new OrientationVector()
+
+type QuatJson = { W: number; X: number; Y: number; Z: number }
+type EulerJson = { roll: number; pitch: number; yaw: number }
+type OvJson = { x: number; y: number; z: number; th: number }
+type OrientJson =
+	| { type: 'quaternion'; value: QuatJson }
+	| { type: 'euler_angles'; value: EulerJson }
+	| { type: 'ov_degrees'; value: OvJson }
+	| { type: 'ov_radians'; value: OvJson }
+	| undefined
+type Vec3Json = { X: number; Y: number; Z: number } | undefined
+
+const hasOrientJson = (orientation: OrientJson): orientation is NonNullable<OrientJson> =>
+	orientation?.type === 'quaternion' ||
+	orientation?.type === 'euler_angles' ||
+	orientation?.type === 'ov_degrees' ||
+	orientation?.type === 'ov_radians'
+
+/** Write orientation JSON into `out`. RDK euler_angles use Tait–Bryan Z-Y′-X″ (ZYX). */
+const quatFromJson = (orientation: OrientJson, out: Quaternion): Quaternion => {
+	if (orientation?.type === 'quaternion' && orientation.value) {
+		const v = orientation.value
+		// Three.js Quaternion order: (x, y, z, w) — W is LAST
+		return out.set(v.X, v.Y, v.Z, v.W)
+	}
+	if (orientation?.type === 'euler_angles' && orientation.value) {
+		const v = orientation.value
+		tmpE.set(v.roll, v.pitch, v.yaw, 'ZYX')
+		return out.setFromEuler(tmpE)
+	}
+	if (orientation?.type === 'ov_radians' && orientation.value) {
+		const v = orientation.value
+		return tmpOv.set(v.x, v.y, v.z, v.th).toQuaternion(out)
+	}
+	if (orientation?.type === 'ov_degrees' && orientation.value) {
+		const v = orientation.value
+		const th = MathUtils.degToRad(v.th ?? 0)
+		return tmpOv.set(v.x, v.y, v.z, th).toQuaternion(out)
+	}
+	return out.set(0, 0, 0, 1)
+}
+
+const poseFromFrame = (translation: Vec3Json, orientation: OrientJson): Pose => {
+	const pose = new Pose({
+		x: translation?.X ?? 0,
+		y: translation?.Y ?? 0,
+		z: translation?.Z ?? 0,
+	})
+	quaternionToPose(quatFromJson(orientation, tmpQ), pose)
+	return pose
+}
+
+type FramePoseJson = { translation?: Vec3Json; orientation?: OrientJson }
+
+/**
+ * Convert a geometry center pose from parent-frame coordinates into the link
+ * frame's local coordinates.
+ *
+ * Both the link frame and geometry center are expressed in the same parent
+ * frame. The link frame pose places the frame origin; the geometry describes
+ * the physical link body (length/shape) with its center offset in parent space.
+ */
+const geometryCenterInFrame = (
+	geoTrans: Vec3Json,
+	geoOrient: OrientJson,
+	framePose: FramePoseJson
+): Pose => {
+	quatFromJson(framePose.orientation, tmpQFrame)
+	tmpQInv.copy(tmpQFrame).invert()
+
+	tmpV
+		.set(
+			(geoTrans?.X ?? 0) - (framePose.translation?.X ?? 0),
+			(geoTrans?.Y ?? 0) - (framePose.translation?.Y ?? 0),
+			(geoTrans?.Z ?? 0) - (framePose.translation?.Z ?? 0)
+		)
+		.applyQuaternion(tmpQInv)
+
+	const center = new Pose({ x: tmpV.x, y: tmpV.y, z: tmpV.z })
+
+	if (hasOrientJson(geoOrient)) {
+		quatFromJson(geoOrient, tmpQGeo)
+		tmpQLocal.copy(tmpQInv).multiply(tmpQGeo)
+		quaternionToPose(tmpQLocal, center)
+	}
+
+	return center
+}
+
+/**
+ * Parse a geometry from raw JSON, returning a proto Geometry.
+ *
+ * For named arm link frames, pass `framePose` so the geometry center (which is
+ * in parent-frame coordinates alongside the link frame) is converted to local
+ * coordinates via R_frame⁻¹.
+ *
+ * For tail_geometry_static / static frames, omit `framePose` — geometry is
+ * already in local coordinates.
+ */
+const parseGeometry = (geom: unknown, framePose?: FramePoseJson): Geometry | null => {
+	if (!geom || typeof geom !== 'object') return null
+	const g = geom as Record<string, unknown>
+	const type = g.type as string
+	if (type !== 'box' && type !== 'sphere' && type !== 'capsule') return null
+
+	const trans = g.translation as Vec3Json
+	const orient = g.orientation as OrientJson
+	const center = framePose
+		? geometryCenterInFrame(trans, orient, framePose)
+		: (() => {
+				const local = new Pose({
+					x: trans?.X ?? 0,
+					y: trans?.Y ?? 0,
+					z: trans?.Z ?? 0,
+				})
+				if (hasOrientJson(orient)) {
+					quaternionToPose(quatFromJson(orient, tmpQ), local)
+				}
+				return local
+			})()
+
+	const label = (g.Label ?? g.label ?? '') as string
+
+	if (type === 'sphere') {
+		return new Geometry({
+			center,
+			geometryType: { case: 'sphere', value: new Sphere({ radiusMm: (g.r as number) ?? 0 }) },
+			label,
+		})
+	}
+	if (type === 'capsule') {
+		return new Geometry({
+			center,
+			geometryType: {
+				case: 'capsule',
+				value: new Capsule({ radiusMm: (g.r as number) ?? 0, lengthMm: (g.l as number) ?? 0 }),
+			},
+			label,
+		})
+	}
+	return new Geometry({
+		center,
+		geometryType: {
+			case: 'box',
+			value: new RectangularPrism({
+				dimsMm: new ViamVector3({
+					x: (g.x as number) ?? 0,
+					y: (g.y as number) ?? 0,
+					z: (g.z as number) ?? 0,
+				}),
+			}),
+		},
+		label,
+	})
+}
+
+export const buildFrameDescriptors = (plan: ParsedPlan): FrameDescriptor[] => {
+	const { frames, parents } = plan
+
+	// Pass 1: map component name → ordered joint frame names (from "model" frames).
+	// This gives us the index each joint occupies in the trajectory array.
+	const jointMap = new Map<string, string[]>()
+	for (const [frameName, entry] of Object.entries(frames)) {
+		if (entry.frame_type !== 'model') continue
+		const model = (entry.frame as Record<string, unknown>).model as
+			| Record<string, unknown>
+			| undefined
+		const joints = model?.joints as Array<{ id: string }> | undefined
+		if (!joints) continue
+		jointMap.set(
+			frameName,
+			joints.map((j) => `${frameName}:${j.id}`)
+		)
+	}
+
+	// Pass 1b: map model frame name → its end-effector static frame name.
+	// External components (cameras, remote grippers) have parent = model frame name in the
+	// JSON, but the model frame itself is never an ECS entity. Reparent them to the terminal
+	// static frame so they appear at the arm's end-effector instead of floating at origin.
+	//
+	// Prefer primary_output_frame from model metadata; fall back to the last entry in
+	// model.links (always the end-effector in Viam's kinematic format). If neither is
+	// present, use the static frame parented to the last joint.
+	const modelTerminalMap = new Map<string, string>()
+	for (const [frameName, entry] of Object.entries(frames)) {
+		if (entry.frame_type !== 'model') continue
+		const model = (entry.frame as Record<string, unknown>).model as
+			| Record<string, unknown>
+			| undefined
+		const primaryOutput = model?.primary_output_frame as string | undefined
+		const links = model?.links as Array<{ id: string }> | undefined
+		const endEffectorId = primaryOutput ?? links?.at(-1)?.id
+		if (endEffectorId) {
+			modelTerminalMap.set(frameName, `${frameName}:${endEffectorId}`)
+			continue
+		}
+		const jointNames = jointMap.get(frameName)
+		const lastJoint = jointNames?.at(-1)
+		if (!lastJoint) continue
+		for (const [childFrame, parentName] of Object.entries(parents)) {
+			if (parentName === lastJoint) {
+				modelTerminalMap.set(frameName, childFrame)
+				break
+			}
+		}
+	}
+
+	// Pass 2: emit one descriptor per frame. Joint frames become JointFrameDescriptors
+	// (their pose is computed from the trajectory at each step). All other frames
+	// become StaticFrameDescriptors with a fixed local pose.
+	const descriptors: FrameDescriptor[] = []
+
+	for (const [frameName, entry] of Object.entries(frames)) {
+		const rawParent = parents[frameName] ?? 'world'
+		const parent = modelTerminalMap.get(rawParent) ?? rawParent
+
+		switch (entry.frame_type) {
+			case 'model': {
+				continue
+			}
+
+			case 'named': {
+				const outer = entry.frame as Record<string, unknown>
+				const inner = outer.inner_frame as Record<string, unknown>
+
+				if (inner.frame_type === 'rotational') {
+					const innerData = inner.frame as Record<string, unknown>
+
+					let componentName = ''
+					let jointIndex = -1
+					for (const [comp, names] of jointMap) {
+						const idx = names.indexOf(frameName)
+						if (idx !== -1) {
+							componentName = comp
+							jointIndex = idx
+							break
+						}
+					}
+					if (!componentName) continue
+
+					descriptors.push({
+						kind: 'joint',
+						name: frameName,
+						parent,
+						axis: innerData.axis as { X: number; Y: number; Z: number },
+						componentName,
+						jointIndex,
+						uuid: planUuid(),
+					})
+				} else if (inner.frame_type === 'static') {
+					const innerData = inner.frame as Record<string, unknown>
+					const framePose: FramePoseJson = {
+						translation: innerData.translation as Vec3Json,
+						orientation: innerData.orientation as OrientJson,
+					}
+					descriptors.push({
+						kind: 'static',
+						name: frameName,
+						parent,
+						localPose: poseFromFrame(framePose.translation, framePose.orientation),
+						geometry: parseGeometry(innerData.geometry, framePose),
+						uuid: planUuid(),
+					})
+				}
+				break
+			}
+
+			case 'tail_geometry_static':
+			case 'static': {
+				const frame = entry.frame as Record<string, unknown>
+				descriptors.push({
+					kind: 'static',
+					name: frameName,
+					parent,
+					localPose: poseFromFrame(frame.translation as Vec3Json, frame.orientation as OrientJson),
+					geometry: parseGeometry(frame.geometry),
+					uuid: planUuid(),
+				})
+				break
+			}
+		}
+	}
+
+	return descriptors
+}

--- a/src/lib/plugins/MotionPlanReplayer/plan-uuid.ts
+++ b/src/lib/plugins/MotionPlanReplayer/plan-uuid.ts
@@ -1,0 +1,7 @@
+import { UuidTool } from 'uuid-tool'
+
+export const planUuid = (): Uint8Array<ArrayBuffer> => {
+	const bytes = new Uint8Array(new ArrayBuffer(16))
+	bytes.set(UuidTool.toBytes(crypto.randomUUID()))
+	return bytes
+}


### PR DESCRIPTION
Rendering a plan step requires each frame resolved to a concrete transform, but a ParsedPlan only carries raw frame/orientation/geometry JSON. Adds buildFrameDescriptors, converting a ParsedPlan into static and jointed FrameDescriptors -> geometry, orientation conversion (quaternion/euler/orientation-vector), joint-index mapping, and end-effector reparenting.

## Changes
- Frontend: Adds build-frame-descriptors.ts (StaticFrameDescriptor / JointFrameDescriptor / FrameDescriptor) and plan-uuid.ts (stable 16-byte ids for transforms)
- Tests: Adds build-frame-descriptors.spec.ts covering static vs jointed frames, all three orientation encodings, geometry translation, model-frame parenting, and - OV/end-effector remapping

## Stack
- PR #838 
- PR #839 
- PR #840 
- PR #841 
- PR #842
- PR #843
- PR #844

##  Links
- [APP-9316](https://viam.atlassian.net/browse/APP-9316)

## Testing
- Run npx vitest run src/lib/plugins/MotionPlanReplayer/__tests__/build-frame-descriptors.spec.ts
- Confirm descriptors carry the correct parent, pose, and joint indices for each fixture

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

[APP-9316]: https://viam.atlassian.net/browse/APP-9316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ